### PR TITLE
feat(screenshots): add user screenshots route and ScreenshotItem comp…

### DIFF
--- a/src/components/cards/screenshot.tsx
+++ b/src/components/cards/screenshot.tsx
@@ -1,0 +1,82 @@
+import { Link } from "@tanstack/react-router";
+import { Images } from "lucide-react";
+import {
+	Carousel,
+	CarouselContent,
+	CarouselItem,
+	CarouselNext,
+	CarouselPrevious,
+} from "@/components/ui/carousel.tsx";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTrigger,
+} from "../ui/dialog";
+
+interface ScreenshotProps {
+	title: string;
+	url: string;
+	imageURL: string;
+	images: string[];
+}
+
+export function ScreenshotItem({
+	title,
+	url,
+	imageURL,
+	images,
+}: ScreenshotProps) {
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<div className={"cursor-pointer"}>
+					<div className="relative rounded-xl border border-border overflow-hidden aspect-3/4 group">
+						<div
+							className="absolute inset-0 bg-cover bg-center transition-all duration-300 group-hover:opacity-100 opacity-80"
+							style={{
+								backgroundImage: `url("${imageURL}")`,
+							}}
+						/>
+						<div className="absolute inset-0 bg-black/40 transition-all duration-300 group-hover:opacity-0 opacity-100 flex items-center justify-center">
+							<div className="flex items-center gap-2 text-white">
+								<Images size={48} />
+								<span className="font-semibold text-2xl">{images.length}</span>
+							</div>
+						</div>
+					</div>
+					<Link to={url}>
+						<p className="font-bold text-card-foreground mt-2 hover:text-primary transition-colors line-clamp-2">
+							{title}
+						</p>
+					</Link>
+				</div>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-5xl max-h-[90vh] overflow-hidden p-0">
+				<DialogHeader></DialogHeader>
+
+				<Carousel
+					className="w-full px-8 py-6"
+					opts={{
+						loop: true,
+						align: "center",
+					}}
+				>
+					<CarouselContent>
+						{images.map((image) => (
+							<CarouselItem key={image}>
+								<img
+									src={image}
+									className="w-full aspect-video"
+									alt="Screenshot"
+								/>
+							</CarouselItem>
+						))}
+					</CarouselContent>
+					<CarouselPrevious variant="default" className="left-2" />
+					<CarouselNext variant="default" className="right-2" />
+				</Carousel>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/cards/screenshot.tsx
+++ b/src/components/cards/screenshot.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@tanstack/react-router";
 import { Images } from "lucide-react";
 import {
 	Carousel,
@@ -7,12 +6,7 @@ import {
 	CarouselNext,
 	CarouselPrevious,
 } from "@/components/ui/carousel.tsx";
-import {
-	Dialog,
-	DialogContent,
-	DialogHeader,
-	DialogTrigger,
-} from "../ui/dialog";
+import { Dialog, DialogContent, DialogTrigger } from "../ui/dialog";
 
 interface ScreenshotProps {
 	title: string;
@@ -45,16 +39,15 @@ export function ScreenshotItem({
 							</div>
 						</div>
 					</div>
-					<Link to={url}>
-						<p className="font-bold text-card-foreground mt-2 hover:text-primary transition-colors line-clamp-2">
-							{title}
-						</p>
-					</Link>
+					<p className="font-bold text-card-foreground mt-2 hover:text-primary transition-colors line-clamp-2">
+						{title}
+					</p>
 				</div>
 			</DialogTrigger>
-			<DialogContent className="sm:max-w-5xl max-h-[90vh] overflow-hidden p-0">
-				<DialogHeader></DialogHeader>
-
+			<DialogContent
+				className="sm:max-w-5xl max-h-[90vh] overflow-hidden p-0"
+				aria-label={"Gallery"}
+			>
 				<Carousel
 					className="w-full px-8 py-6"
 					opts={{
@@ -63,12 +56,12 @@ export function ScreenshotItem({
 					}}
 				>
 					<CarouselContent>
-						{images.map((image) => (
+						{images.map((image, index) => (
 							<CarouselItem key={image}>
 								<img
 									src={image}
-									className="w-full aspect-video"
-									alt="Screenshot"
+									className="w-full aspect-video object-contain"
+									alt={`${title} – screenshot ${index + 1} of ${images.length}`}
 								/>
 							</CarouselItem>
 						))}

--- a/src/components/cards/screenshot.tsx
+++ b/src/components/cards/screenshot.tsx
@@ -10,17 +10,11 @@ import { Dialog, DialogContent, DialogTrigger } from "../ui/dialog";
 
 interface ScreenshotProps {
 	title: string;
-	url: string;
 	imageURL: string;
 	images: string[];
 }
 
-export function ScreenshotItem({
-	title,
-	url,
-	imageURL,
-	images,
-}: ScreenshotProps) {
+export function ScreenshotItem({ title, imageURL, images }: ScreenshotProps) {
 	return (
 		<Dialog>
 			<DialogTrigger asChild>

--- a/src/routes/user/$username/screenshots/index.tsx
+++ b/src/routes/user/$username/screenshots/index.tsx
@@ -33,7 +33,6 @@ export function ScreenshotsRoute() {
 			description: "1000+ episodes watched",
 		},
 		{ id: "m3", name: "Community Helper", description: "10 helpful reviews" },
-		{ id: "m3", name: "Community Helper", description: "10 helpful reviews" },
 	];
 
 	const gamesWithScreenshots = [
@@ -85,7 +84,7 @@ export function ScreenshotsRoute() {
 					<ScreenshotItem
 						key={f.id}
 						title={f.title}
-						url={"/"}
+						url={`/game/${f.id}`}
 						imageURL={f.image}
 						images={f.images}
 					/>

--- a/src/routes/user/$username/screenshots/index.tsx
+++ b/src/routes/user/$username/screenshots/index.tsx
@@ -1,0 +1,96 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ScreenshotItem } from "@/components/cards/screenshot.tsx";
+import { Grid } from "@/components/layouts/grid.tsx";
+import { UserLayout } from "@/components/layouts/user";
+
+export const Route = createFileRoute("/user/$username/screenshots/")({
+	head: ({ params }) => ({
+		meta: [{ title: `${params.username}'s Screenshots | TrackGeek` }],
+	}),
+	component: ScreenshotsRoute,
+});
+
+export function ScreenshotsRoute() {
+	const { username } = Route.useParams();
+
+	const user = {
+		username,
+		avatarUrl: "https://github.com/Kuriel23.png",
+		bio: "Apaixonada por anime, leitora ávida e avaliadora. Gosto de slice-of-life e sci-fi. Escrevo reviews detalhadas e listas de favoritos.",
+		followers: 324,
+		following: 48,
+	};
+
+	const medals = [
+		{
+			id: "m1",
+			name: "Top Reviewer",
+			description: "100+ reviews and highly rated",
+		},
+		{
+			id: "m2",
+			name: "Marathon Watcher",
+			description: "1000+ episodes watched",
+		},
+		{ id: "m3", name: "Community Helper", description: "10 helpful reviews" },
+		{ id: "m3", name: "Community Helper", description: "10 helpful reviews" },
+	];
+
+	const gamesWithScreenshots = [
+		{
+			id: "a1",
+			title: "Romeo is a Dead Man",
+			image: "https://images.igdb.com/igdb/image/upload/t_original/coakmt.webp",
+			images: [
+				"https://images.igdb.com/igdb/image/upload/t_720p/sc5rik.webp",
+				"https://images.igdb.com/igdb/image/upload/t_720p/sc5ril.webp",
+			],
+		},
+		{
+			id: "a2",
+			title: "Soul Hackers 2",
+			image: "https://images.igdb.com/igdb/image/upload/t_original/co4hzh.webp",
+			images: [
+				"https://images.igdb.com/igdb/image/upload/t_720p/sc5rik.webp",
+				"https://images.igdb.com/igdb/image/upload/t_720p/sc5ril.webp",
+			],
+		},
+		{
+			id: "a3",
+			title: "Grand Theft Auto VI",
+			image: "https://images.igdb.com/igdb/image/upload/t_original/co9rwo.webp",
+			images: [
+				"https://images.igdb.com/igdb/image/upload/t_720p/sc5rik.webp",
+				"https://images.igdb.com/igdb/image/upload/t_720p/sc5ril.webp",
+			],
+		},
+		{
+			id: "a4",
+			title: "Call of Duty: Black Ops 7",
+			image: "https://images.igdb.com/igdb/image/upload/t_original/co9xwv.webp",
+			images: [
+				"https://images.igdb.com/igdb/image/upload/t_720p/sc5rik.webp",
+				"https://images.igdb.com/igdb/image/upload/t_720p/sc5ril.webp",
+			],
+		},
+	];
+
+	return (
+		<UserLayout user={user} medalsCount={medals.length} entriesCount={2}>
+			<Grid
+				minColSize={"128px"}
+				className="flex w-full flex-col rounded-2xl py-4 px-2 gap-6"
+			>
+				{gamesWithScreenshots.map((f) => (
+					<ScreenshotItem
+						key={f.id}
+						title={f.title}
+						url={"/"}
+						imageURL={f.image}
+						images={f.images}
+					/>
+				))}
+			</Grid>
+		</UserLayout>
+	);
+}

--- a/src/routes/user/$username/screenshots/index.tsx
+++ b/src/routes/user/$username/screenshots/index.tsx
@@ -84,7 +84,6 @@ export function ScreenshotsRoute() {
 					<ScreenshotItem
 						key={f.id}
 						title={f.title}
-						url={`/game/${f.id}`}
 						imageURL={f.image}
 						images={f.images}
 					/>


### PR DESCRIPTION
## Description

## Acknowledgements
- [x] I read the [PR Guidelines](https://github.com/TrackGeek/web/blob/main/.github/CONTRIBUTING.md)
- [x] I linted and formatted the code by running `npm run check`
- [x] The PR title follows the repo's [commit conventions](https://github.com/TrackGeek/web/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    At least TWO screenshots of the feature
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Screenshot viewer: clickable thumbnail cards open a modal carousel to browse multiple images, with hover preview, image count indicator, and navigation controls.
  * User screenshots page: personalized grid layout showing users' screenshots organized by game, with titles linking to item views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->