### PR TITLE
feat(anime): add `/anime` route with carousel and grid layouts

### DIFF
--- a/src/lib/i18n/locales/en-US/common.json
+++ b/src/lib/i18n/locales/en-US/common.json
@@ -92,5 +92,8 @@
 	"recentlyReleased": "Recently Released",
 	"comingSoon": "Coming Soon",
 	"mostAnticipated": "Most Anticipated",
-	"viewDetails": "View Details"
+	"viewDetails": "View Details",
+	"topAnime": "Top Anime",
+	"topAiring": "Top Airing",
+	"recommendations": "Recommendations"
 }

--- a/src/lib/mockups/animes.json
+++ b/src/lib/mockups/animes.json
@@ -1,0 +1,11614 @@
+[{
+    "aired": {
+      "from": "2015-07-05T00:00:00+00:00",
+      "prop": {
+        "from": {
+          "day": 5,
+          "month": 7,
+          "year": 2015
+        },
+        "to": {
+          "day": 25,
+          "month": 3,
+          "year": 2018
+        }
+      },
+      "string": "Jul 5, 2015 to Mar 25, 2018",
+      "to": "2018-03-25T00:00:00+00:00"
+    },
+    "background": "Dragon Ball Super's first 27 episodes are adaptations of the films Dragon Ball Z Movie 14: Kami to Kami (episodes 1-14) and Dragon Ball Z Movie 15: Fukkatsu no F (episodes 15-27).",
+    "broadcast": {
+      "day": "Sundays",
+      "string": "Sundays at 09:00 (JST)",
+      "time": "09:00",
+      "timezone": "Asia/Tokyo"
+    },
+    "cast": [
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 11352,
+        "name": "Kitamura, Tomoyuki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 11385,
+        "name": "Kano, Akira",
+        "positions": [
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 15627,
+        "name": "Mori, Hisashi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 19173,
+        "name": "Hayashi, Yuuki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 19924,
+        "name": "Satou, Michio",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 25501,
+        "name": "Kagawa, Hisashi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 28085,
+        "name": "Ohno, Tsutomu",
+        "positions": [
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 36153,
+        "name": "Suzuki, Futoshi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 37823,
+        "name": "Ochi, Kazuhiro",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 38988,
+        "name": "Fukushima, Yoshifumi",
+        "positions": [
+          "Script"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 38995,
+        "name": "Nishimura, Eiichi",
+        "positions": [
+          "Editing"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 39190,
+        "name": "Yamazaki, Hideki",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 40131,
+        "name": "Oonishi, Ryou",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 40450,
+        "name": "Mitsuka, Masato",
+        "positions": [
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 40912,
+        "name": "Miyai, Kana",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 41129,
+        "name": "Tokoro, Toshikatsu",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 41280,
+        "name": "Yokoya, Kenta",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 41885,
+        "name": "Ibata, Shouta",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 41936,
+        "name": "Ogawa, Ichirou",
+        "positions": [
+          "Animation Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 42157,
+        "name": "Yuki, Shinzou",
+        "positions": [
+          "Background Art"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 42829,
+        "name": "Ikeda, Yumi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 43251,
+        "name": "Oonishi, Youichi",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 44418,
+        "name": "Nakano, Akiko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 45479,
+        "name": "Sudarehata, Yumi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 47112,
+        "name": "Wanibuchi, Kazuhiko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 47411,
+        "name": "Karasawa, Yuuichi",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 47645,
+        "name": "Ogawa, Kouji",
+        "positions": [
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 47732,
+        "name": "Takamura, Kaoru",
+        "positions": [
+          "Animation Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 47908,
+        "name": "Nii, Hirotaka",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 47969,
+        "name": "Yamashita, Megumi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 47976,
+        "name": "Iwai, Takao",
+        "positions": [
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 48404,
+        "name": "Houri, Kouji",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 48837,
+        "name": "Higashide, Futoshi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 49099,
+        "name": "Hisao, Ayumu",
+        "positions": [
+          "Script"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 49745,
+        "name": "Yoshitaka, Toshio",
+        "positions": [
+          "Script"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 50592,
+        "name": "Hatano, Kouhei",
+        "positions": [
+          "Director",
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 50626,
+        "name": "Ichino, Maria",
+        "positions": [
+          "2nd Key Animation",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 52442,
+        "name": "Sasakado, Nobuyoshi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 53360,
+        "name": "Yoshiyama, Yuu",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 53937,
+        "name": "Akizuki, Aya",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 54623,
+        "name": "Kawasaki, Rena",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 54870,
+        "name": "Majima, Takahiro",
+        "positions": [
+          "Episode Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 5659,
+        "name": "Matsui, Hitoyuki",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 59630,
+        "name": "Aizu, Satsuki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 60753,
+        "name": "Tsukuma, Takenori",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 61295,
+        "name": "Takeshita, Kenichi",
+        "positions": [
+          "Episode Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 61926,
+        "name": "Matsumoto, Katsuji",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 61927,
+        "name": "Takemori, Yuka",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 61943,
+        "name": "Ikai, Kazuyuki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 62022,
+        "name": "Hagiwara, Masato",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 62392,
+        "name": "Katou, Yoshitaka",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 62442,
+        "name": "Morinaka, Masaharu",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 62729,
+        "name": "Urata, Yukihiro",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 62844,
+        "name": "Iizuka, Youko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 63367,
+        "name": "Matsuo, Shunsuke",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 63399,
+        "name": "Nakaji, Asuka",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 63431,
+        "name": "Nakamura, Shinya",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 65162,
+        "name": "Tanaka, Moe",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 65853,
+        "name": "Tu, Yong Ce",
+        "positions": [
+          "2nd Key Animation",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 65921,
+        "name": "Yamauchi, Naoki",
+        "positions": [
+          "Animation Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 66521,
+        "name": "Taniguchi, Kousaku",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 67152,
+        "name": "Enomoto, Mamoru",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 67542,
+        "name": "Washikita, Kyouta",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 67778,
+        "name": "Kamata, Hitoshi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 68307,
+        "name": "Hiroshima, Hideki",
+        "positions": [
+          "Episode Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 68483,
+        "name": "Hoshino, Reika",
+        "positions": [
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 68524,
+        "name": "Nakao, Yukihiko",
+        "positions": [
+          "Episode Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 6936,
+        "name": "Kobayashi, Yukari",
+        "positions": [
+          "Assistant Animation Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 69959,
+        "name": "Yashima, Yoshitaka",
+        "positions": [
+          "2nd Key Animation",
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 70037,
+        "name": "Koremoto, Akira",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 70349,
+        "name": "Maruyama, Hirokatsu",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 70368,
+        "name": "Iwadare, Mizuki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 70495,
+        "name": "Yamada, Kanari",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 70501,
+        "name": "Shimazaki, Nozomi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 70720,
+        "name": "Usuda, Yoshio",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 71169,
+        "name": "Tanaka, Takayuki",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 71653,
+        "name": "Numata, Hiroshi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 71774,
+        "name": "Higaki, Kenichi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 71805,
+        "name": "Hayase, Makiko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 71916,
+        "name": "Ooshima, Touya",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 72436,
+        "name": "Komura, Yuzuha",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 72587,
+        "name": "Satou, Masanori",
+        "positions": [
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 72730,
+        "name": "Toriyama, Fuyumi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 72908,
+        "name": "Nishikawa, Masato",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73133,
+        "name": "Kinoshita, Yui",
+        "positions": [
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73195,
+        "name": "Noji, Kiyoshi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73200,
+        "name": "Hong, Beom-seok",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73258,
+        "name": "Fukuhara, Keiji",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73288,
+        "name": "Abe, Akari",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73289,
+        "name": "Satou, Aika",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73356,
+        "name": "Kanakubo, Norie",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73361,
+        "name": "Hosokawa, Shuuhei",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73396,
+        "name": "Ikeda, Tomomi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73478,
+        "name": "Narimatsu, Yoshito",
+        "positions": [
+          "Animation Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73487,
+        "name": "Lee, Ju-hyeon",
+        "positions": [
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73653,
+        "name": "Shima, Arisa",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 73942,
+        "name": "Park, Jae-suk",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74069,
+        "name": "Muroyama, Shouko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74070,
+        "name": "Kinoshita, Yumiko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74127,
+        "name": "Kusunoki, Tomoko",
+        "positions": [
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74162,
+        "name": "Fujiwara, Mikio",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74260,
+        "name": "Makabe, Tomoyuki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74263,
+        "name": "Sakamoto, Nozomi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74264,
+        "name": "Shijou, Yukimasa",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74327,
+        "name": "Takemoto, Yoshiko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74328,
+        "name": "Ushinohama, Yui",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74428,
+        "name": "Koyama, Makoto",
+        "positions": [
+          "Script"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74744,
+        "name": "Tsuji, Miyako",
+        "positions": [
+          "Chief Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74775,
+        "name": "Ono, Ayumu",
+        "positions": [
+          "Assistant Animation Director",
+          "Episode Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74795,
+        "name": "Hatanaka, Taichi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74941,
+        "name": "Fukushima, Toyoaki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 74983,
+        "name": "Kim, Su-ho",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 75482,
+        "name": "Osada, Yuuki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 75483,
+        "name": "Aoki, Akihito",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 75748,
+        "name": "Ogata, Daisuke",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 75753,
+        "name": "Hanazawa, Yuri",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 75855,
+        "name": "Tsukino, Mua",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 75960,
+        "name": "Aoyagi, Shigemi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 76359,
+        "name": "Yoshimoto, Masakazu",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 76592,
+        "name": "Namatame, Yasuhiro",
+        "positions": [
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 77054,
+        "name": "Kawasaki, Kouji",
+        "positions": [
+          "Episode Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 77094,
+        "name": "Yu, Hyo-sang",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 77343,
+        "name": "Iwata, Koudai",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 77383,
+        "name": "Nozaki, Shinichi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 78215,
+        "name": "Hatano, Yoshitsugu",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 78306,
+        "name": "Kitagawa, Tomoko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 78307,
+        "name": "Murakami, Erina",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 78521,
+        "name": "Nikaidou, Atsushi",
+        "positions": [
+          "2nd Key Animation",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 78672,
+        "name": "Komatsu, Yui",
+        "positions": [
+          "Episode Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 79370,
+        "name": "Kobayashi, Ichizou",
+        "positions": [
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 79503,
+        "name": "Kim, Shin-woo",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 79516,
+        "name": "Matsuzaka, Sadatoshi",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 79648,
+        "name": "Sugiura, Keiichi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 79912,
+        "name": "Ootaka, Yuuta",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80046,
+        "name": "Ikeda, Hiroaki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80098,
+        "name": "Hakamada, Yuuji",
+        "positions": [
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80103,
+        "name": "Sawaki, Midori",
+        "positions": [
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80114,
+        "name": "Oda, Taeko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80163,
+        "name": "Yamauchi, Aki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80202,
+        "name": "Maruyama, Masahiko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80737,
+        "name": "Hashimoto, Kouhei",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80811,
+        "name": "Satou, Tomoko",
+        "positions": [
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80852,
+        "name": "Yagi, Motoki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80857,
+        "name": "Fukushima, Youko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80922,
+        "name": "Itou, Hiroki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 80937,
+        "name": "Matsui, Kyousuke",
+        "positions": [
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 81857,
+        "name": "Maita, Yuuya",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 81859,
+        "name": "Lee, Woong-jae",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 81966,
+        "name": "Hirabayashi, Takashi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 82087,
+        "name": "Abe, Sakuya",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 82634,
+        "name": "Iwata, Yoshimi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 82657,
+        "name": "Nakamura, Junko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 82863,
+        "name": "Hoshino, Mamoru",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 83301,
+        "name": "Sugawara, Miyuki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 83376,
+        "name": "Kim, Bong-duk",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 83435,
+        "name": "Hamakawa, Shuujirou",
+        "positions": [
+          "Animation Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 83457,
+        "name": "Tsugihashi, Yuki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 84315,
+        "name": "Teramoto, Satoshi",
+        "positions": [
+          "Producer"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 84344,
+        "name": "Shinohara, Hana",
+        "positions": [
+          "Episode Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 84422,
+        "name": "Chang, Shaowei",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 84557,
+        "name": "Kim, Ik-yeon",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 84694,
+        "name": "Sokabe, Takashi",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 84698,
+        "name": "Yamamoto, Takanori",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 84959,
+        "name": "Shin, Young-soon",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 85288,
+        "name": "Yamakita, Takahiro",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 85860,
+        "name": "Ami, Kou",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 86430,
+        "name": "Tezuka, Emi",
+        "positions": [
+          "2nd Key Animation",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 86478,
+        "name": "Matsuo, Yuu",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 86872,
+        "name": "Shimizu, Shintarou",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 86900,
+        "name": "Kubo, Mitsuteru",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 87509,
+        "name": "Yamazaki, Ai",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 87700,
+        "name": "Kitano, Yukihiro",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 87784,
+        "name": "Tanoue, Makoto",
+        "positions": [
+          "Animation Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 8804,
+        "name": "Shimanuki, Masahiro",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 88980,
+        "name": "Tomiyoshi, Kouki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 89520,
+        "name": "Hayashi, Yasuhiro",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 89697,
+        "name": "Itou, Hirotaka",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 90182,
+        "name": "Sagawa, Naoko",
+        "positions": [
+          "Producer"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 90312,
+        "name": "Nakamura, Midori",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 90809,
+        "name": "Hironaka, Mika",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 90888,
+        "name": "Arukara",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 91248,
+        "name": "Usami, Shouhei",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 92641,
+        "name": "Kizaki, Yukari",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 9301,
+        "name": "Kado, Tomoaki",
+        "positions": [
+          "2nd Key Animation",
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 9453,
+        "name": "Ooshita, Tomoyuki",
+        "positions": [
+          "2nd Key Animation",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37565.jpg?s=1dfcf9f93f30bc9e2d0f7b982559958d",
+        "malId": 35739,
+        "name": "Yamamuro, Tadayoshi",
+        "positions": [
+          "Animation Director",
+          "Character Design",
+          "Chief Animation Director",
+          "Key Animation",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/42755.jpg?s=b591ace59c452edcff42e37cc6cd9cf6",
+        "malId": 21257,
+        "name": "Imamura, Takahiro",
+        "positions": [
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/45234.jpg?s=b9fce572e7a9f0f4f116e08b5d5c4276",
+        "malId": 11924,
+        "name": "Shida, Naotoshi",
+        "positions": [
+          "Key Animation",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46826.jpg?s=664a392f1c3e8dadde779d6a145c0877",
+        "malId": 16685,
+        "name": "Chioka, Kimitoshi",
+        "positions": [
+          "Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48316.jpg?s=97b669f3854e0d4add5ef4208fb2c593",
+        "malId": 43639,
+        "name": "Rossatto, Raphael",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48916.jpg?s=5883b5d01905172dbfef7d4d39484af6",
+        "malId": 42872,
+        "name": "Sharp, Nathan",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/53754.jpg?s=c04c9008e0062e410776ad538957f9df",
+        "malId": 39022,
+        "name": "Murano, Yuuta",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/5638.jpg?s=dd66476d1aa36847827d6bce7259ba32",
+        "malId": 8469,
+        "name": "Tate, Naoki",
+        "positions": [
+          "Animation Director",
+          "Assistant Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/57980.jpg?s=4be00498189b24587e1b43c6cbaa0d2b",
+        "malId": 47670,
+        "name": "Watanabe, Koudai",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/58037.jpg?s=e205b904453f01aab62a6d27413c6184",
+        "malId": 47889,
+        "name": "Hikawa, Kiyoshi",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/58039.jpg?s=fdb60363a608f7e437dca50865153777",
+        "malId": 9809,
+        "name": "Cruz, Ricardo",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68622.jpg?s=ee74f7a2bf90745b196f96585b99d683",
+        "malId": 57380,
+        "name": "Panetto, Anthony",
+        "positions": [
+          "Script"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/72454.jpg?s=d4ec29f9fc7d501e80f45a589f991350",
+        "malId": 49290,
+        "name": "Yatabe, Touko",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/72491.jpg?s=966c60dffc829835023ae8bb28cea7ad",
+        "malId": 63125,
+        "name": "Sutter, Bruno",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/77639.jpg?s=2f70420806226276cd60bb8f3f653bac",
+        "malId": 15799,
+        "name": "Hatano, Morio",
+        "positions": [
+          "Director",
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80501.jpg?s=ee808f428c434aee43fe003623f6bf0b",
+        "malId": 203,
+        "name": "Cook, Justin",
+        "positions": [
+          "Producer"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/82440.jpg?s=805fddeb87316f89cf9ec430a561ac7b",
+        "malId": 78981,
+        "name": "Hoyos, Mercedes",
+        "positions": [
+          "ADR Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/84053.jpg?s=8cb00d0d970e6d9d37a6bd6b0288b71a",
+        "malId": 27397,
+        "name": "Abe, Misao",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/87404.jpg?s=b866e02aaa203c3fea312ebdbfb9bc56",
+        "malId": 90891,
+        "name": "LACCO TOWER",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/87409.jpg?s=acf07335d57df43ee07a7315ca89990d",
+        "malId": 90887,
+        "name": "The Collectors",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/87414.jpg?s=82fe8ff8e6c9708adff5daeff9ea1f76",
+        "malId": 90885,
+        "name": "ROTTENGRAFFTY",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/88420.jpg?s=080d977bb8284cbaf74140c7f86b6dfc",
+        "malId": 72106,
+        "name": "Hattori, Masumi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/36483.jpg?s=6295fbddb2b459fe14c0b1f412ad2fce",
+        "malId": 32661,
+        "name": "Good Morning America",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/45873.jpg?s=613fe8e8d061244cc9cd04ed00837e7d",
+        "malId": 12642,
+        "name": "NARASAKI",
+        "positions": [
+          "Theme Song Arrangement"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47037.jpg?s=37f4852cc33999c2a55d1986f75b68f2",
+        "malId": 19431,
+        "name": "Toyotarou",
+        "positions": [
+          "Original Character Design"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/49039.jpg?s=27bb36a23050e9edc232225a721d7e8f",
+        "malId": 8698,
+        "name": "Kaizawa, Yukio",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/50363.jpg?s=7a520197613b5c446bc057bdb47fc67f",
+        "malId": 20058,
+        "name": "Shimizu, Junji",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/53612.jpg?s=12c2649180234be7f5af10fa1663c9e7",
+        "malId": 12867,
+        "name": "Nagamine, Tatsuya",
+        "positions": [
+          "Director",
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/55240.jpg?s=f550f8fd91da674a6726faf33d39e167",
+        "malId": 48925,
+        "name": "ONEPIXCEL",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+        "malId": 26393,
+        "name": "Nouel, Antoine",
+        "positions": [
+          "ADR Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/74992.jpg?s=3ba6936098f9bcc0477fd549557a685c",
+        "malId": 65409,
+        "name": "Fujimoto, Kouki",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77640.jpg?s=204e4fa0fadc6f2bc072c04f88fe5378",
+        "malId": 47941,
+        "name": "Nakamura, Ryouta",
+        "positions": [
+          "Director",
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/79466.jpg?s=c4d7b70a54688324e9720ab81cd85f09",
+        "malId": 72323,
+        "name": "Castro, Cidalia",
+        "positions": [
+          "Theme Song Lyrics"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80645.jpg?s=355c6c8332a4c3c06ffad85d40696930",
+        "malId": 19842,
+        "name": "Yamaguchi, Yuuji",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/81502.jpg?s=33c88217aa6903d4875b93fb3cee36ed",
+        "malId": 75472,
+        "name": "Mori, Yukinojo",
+        "positions": [
+          "Theme Song Lyrics"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/87397.jpg?s=cb1b89626cca67a01edc4066ab2e8bb8",
+        "malId": 90892,
+        "name": "Yoshii, Kazuya",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/87405.jpg?s=8b0148592a636a9dfed8d790eb0e51f8",
+        "malId": 90890,
+        "name": "Czecho No Republic",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/87406.jpg?s=01c58261f4f005d11af4af79fc3f1a67",
+        "malId": 90889,
+        "name": "Batten Shoujo-tai",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/11246.jpg?s=744c2a1513243ffd302809e5086fe736",
+        "malId": 11970,
+        "name": "Mendelman, Ami",
+        "positions": [
+          "Theme Song Lyrics",
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/11718.jpg?s=2873518e739f6aa2150f82622db12631",
+        "malId": 7491,
+        "name": "Kushida, Akira",
+        "positions": [
+          "Inserted Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/12737.jpg?s=d607b085e1268a81136ecc2ebc661b45",
+        "malId": 2797,
+        "name": "Mori, Takeshi",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/14747.jpg?s=00de0eee0c585f26ac4985b809d70a87",
+        "malId": 14339,
+        "name": "Tomioka, Atsuhiro",
+        "positions": [
+          "Script"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/19913.jpg?s=37f6b1e6a23295acd2433b48467e9579",
+        "malId": 11638,
+        "name": "Taniguchi, Moriyasu",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/22415.jpg?s=3273fe1af71b6666100b502cb594e8d3",
+        "malId": 19926,
+        "name": "Satou, Gen",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/24531.jpg?s=2a6f723551d11d118ec219562b3edb2f",
+        "malId": 5316,
+        "name": "Fukunaga, Gen",
+        "positions": [
+          "Executive Producer"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/40043.jpg?s=0704c0db314d9a911202cb56d0076f99",
+        "malId": 1901,
+        "name": "Toriyama, Akira",
+        "positions": [
+          "Original Character Design",
+          "Original Creator",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+        "malId": 253,
+        "name": "Sabat, Christopher",
+        "positions": [
+          "ADR Director",
+          "Producer"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/43698.jpg?s=5a3fe1a66fc5fc440f616b3dae441381",
+        "malId": 43250,
+        "name": "Ishitani, Megumi",
+        "positions": [
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/45489.jpg?s=3e41f0fbe0dcc0939df9f0883cc99511",
+        "malId": 40519,
+        "name": "Itou, Naoyuki",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/46640.jpg?s=eaf1560b8fc0b3f0445f965c8faa8068",
+        "malId": 35461,
+        "name": "Iseki, Shuuichi",
+        "positions": [
+          "Animation Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/51850.jpg?s=0feffd871abbf8531591797b764a11e2",
+        "malId": 47690,
+        "name": "Kameda, Seiji",
+        "positions": [
+          "Theme Song Arrangement"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/53313.jpg?s=9fa0b127ef30a8b4bdaeb384e7350404",
+        "malId": 31851,
+        "name": "Sumitomo, Norihito",
+        "positions": [
+          "Music"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/53748.jpg?s=de79b529bc50d94329772c9125314bc6",
+        "malId": 32969,
+        "name": "Furuta, Jouji",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/54369.jpg?s=5af124ba3713c33cdcb91760aee5ecd2",
+        "malId": 17849,
+        "name": "Honda, Yasunori",
+        "positions": [
+          "Sound Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/54644.jpg?s=b393c7ca04f2e1304d59c0ec9a42ef8d",
+        "malId": 40537,
+        "name": "Kakudou, Hiroyuki",
+        "positions": [
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/57904.jpg?s=77955a24277020af709dbc2fe64798a5",
+        "malId": 38681,
+        "name": "Ootsuka, Ken",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/60262.jpg?s=5c7ea79d6f0cac04c873185e09cb31ae",
+        "malId": 7974,
+        "name": "Lima, Wellington",
+        "positions": [
+          "ADR Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/61222.jpg?s=56480c6e6283f5833eac72fa85e280f9",
+        "malId": 8241,
+        "name": "Bezerra, Úrsula",
+        "positions": [
+          "ADR Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/61649.jpg?s=c725d5165cc786cdf3f942b1a1272ed9",
+        "malId": 43991,
+        "name": "Milani, Gaby",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/61829.jpg?s=ff67d5849be65fe9d4513402a40fa9d3",
+        "malId": 47412,
+        "name": "Takahashi, Yuya",
+        "positions": [
+          "Animation Director",
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/62011.jpg?s=85aa3d673fadd77b07dbfa76fa077a6f",
+        "malId": 51363,
+        "name": "Karasawa, Kazuya",
+        "positions": [
+          "Episode Director",
+          "Storyboard"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/64954.jpg?s=300e32f837a9290f8448170ab9ae6d0e",
+        "malId": 7937,
+        "name": "Nakatsuru, Katsuyoshi",
+        "positions": [
+          "Key Animation"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68498.jpg?s=3de3b17beea5590b7f85969262cb0ed3",
+        "malId": 7094,
+        "name": "Garza, Eduardo",
+        "positions": [
+          "ADR Director",
+          "Dialogue Editing"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68633.jpg?s=6f323396ad25d0bb5b268c68bb1e5849",
+        "malId": 57591,
+        "name": "Duclos, Didier",
+        "positions": [
+          "Script"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/74638.jpg?s=7f5fd56efee675d65b56bf1c154a10f6",
+        "malId": 65072,
+        "name": "Herek, Samantha",
+        "positions": [
+          "Assistant Producer"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/75915.jpg?s=316e3918010e01a30c5754942cde27b9",
+        "malId": 1830,
+        "name": "Bezerra, Wendel",
+        "positions": [
+          "ADR Director",
+          "Casting Director",
+          "Producer",
+          "Theme Song Lyrics"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/80225.jpg?s=9052029e51271bd603f94a90b5c181df",
+        "malId": 62869,
+        "name": "Rossi, Rodrigo",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85012.jpg?s=fbef5690e3a75ae413f47130adef7e84",
+        "malId": 84900,
+        "name": "Lamoureux, Charles",
+        "positions": [
+          "Casting Director"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/87403.jpg?s=e9a5420d93c9c30534ad317e1b206ee7",
+        "malId": 38026,
+        "name": "KEYTALK",
+        "positions": [
+          "Theme Song Arrangement",
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/87410.jpg?s=39fcc5836de28fe255a746a40e77ba0f",
+        "malId": 90886,
+        "name": "Inoue, Miyu",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/88526.jpg?s=bdf1ff7ad59d912b4c476644210eca16",
+        "malId": 43669,
+        "name": "Fábio, Ricardo",
+        "positions": [
+          "Theme Song Performance"
+        ]
+      }
+    ],
+    "characters": [
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/10/273651.jpg?s=590ff5cc764dec32bfe19a21966abc78",
+        "malId": 6130,
+        "name": "Babidi",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/10/273659.jpg?s=f8257b7ca972acd4445bc49b8d995d4f",
+        "malId": 6132,
+        "name": "Dabura",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/10127.jpg?s=50713fb59858af5a9668701332ee53b3",
+            "language": "Japanese",
+            "malId": 836,
+            "name": "Ootomo, Ryuuzaburou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/21173.jpg?s=65e5fe4931e250c52790cc32d250cbb0",
+            "language": "English",
+            "malId": 7494,
+            "name": "Robertson, Rick"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68785.jpg?s=82186dcbe4757f29bd52e96e20cdee20",
+            "language": "Spanish",
+            "malId": 57431,
+            "name": "Pingarrón, Gabriel"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/10/357367.jpg?s=55560e6f34e553a8ad893ddbb47aec84",
+        "malId": 154839,
+        "name": "Korn",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67235.jpg?s=fea908e2616dad8137bce32cc7a80a61",
+            "language": "Portuguese (BR)",
+            "malId": 21197,
+            "name": "Lima, Diego"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/10/357379.jpg?s=4e6fb94eaebd27b612cefb6003835888",
+        "malId": 154835,
+        "name": "Awamo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85358.jpg?s=f57ecefc66da2b2ae81fa7e1ac0a339e",
+            "language": "Portuguese (BR)",
+            "malId": 52960,
+            "name": "Córdova, Thiago"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/10/358456.jpg?s=7b5569aa7a97ac9c1ea6f7ce950fb6ab",
+        "malId": 2143,
+        "name": "Mai",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30191.jpg?s=ae2728aa271ed956b5a0b72e7a047cbc",
+            "language": "English",
+            "malId": 472,
+            "name": "Clinkenbeard, Colleen"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68352.jpg?s=f4b00abdda83a02fa853cca4a52681cf",
+            "language": "Portuguese (BR)",
+            "malId": 5136,
+            "name": "Quinto, Letícia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/75685.jpg?s=ab2b3d91b1dcd7e6656b16b4a7ab232d",
+            "language": "Japanese",
+            "malId": 5763,
+            "name": "Yamada, Eiko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/88389.jpg?s=141ebb466c6b932c80b656dd4ec7bf65",
+            "language": "Hungarian",
+            "malId": 62772,
+            "name": "Hermann, Lilla"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/32687.jpg?s=d9e617b645dbafdbee1c2f3c66d46140",
+            "language": "French",
+            "malId": 31621,
+            "name": "Ropion, Joséphine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/44898.jpg?s=1d01ff0a5328346c5909145b1ae6557f",
+            "language": "English",
+            "malId": 1065,
+            "name": "Maddalena, Julie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68412.jpg?s=cde299cfc49448a3f526e439dbbc9b7d",
+            "language": "Spanish",
+            "malId": 44721,
+            "name": "Moreno, Susana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/36819.jpg?s=1f93482483e04ec21b6608c471a0c485",
+            "language": "Italian",
+            "malId": 35383,
+            "name": "Pallavicino, Valentina"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/10/366264.jpg?s=fa4556a93da9d6373d2edb8b93e60590",
+        "malId": 6293,
+        "name": "Rou Kaioshin",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/41889.jpg?s=3324bba7150b682ff227a0c082a93293",
+            "language": "English",
+            "malId": 990,
+            "name": "Kramer, Steve"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68349.jpg?s=1dd4f6605cd9cb13e9bc2b1a451b37b3",
+            "language": "Portuguese (BR)",
+            "malId": 5605,
+            "name": "Romero, Cássius"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/18159.jpg?s=3d7951b5c204e9befd0987e104267682",
+            "language": "Japanese",
+            "malId": 1675,
+            "name": "Tanaka, Ryouichi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46741.jpg?s=3b9f0663cd9c6a33fab6b1d8eb77235a",
+            "language": "Portuguese (BR)",
+            "malId": 43077,
+            "name": "Feist, Henrique"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/50611.jpg?s=3465f2d57eabc011d155724dd1b8f813",
+            "language": "Spanish",
+            "malId": 46818,
+            "name": "Hidalgo, Alberto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/5588.jpg?s=9f3ab20aa2fb125426192e17b916e670",
+            "language": "Hungarian",
+            "malId": 8387,
+            "name": "Botár, Endre"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/22441.jpg?s=e5bf37525a336367437632cf819e41f1",
+            "language": "Italian",
+            "malId": 20260,
+            "name": "Scattorin, Maurizio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/24639.jpg?s=a5602f2f8b05a85abd8793ee1a41e71b",
+            "language": "Spanish",
+            "malId": 21469,
+            "name": "Lezama, Ernesto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/40726.jpg?s=a4860e1836e7a8485ae21178dfc96389",
+            "language": "English",
+            "malId": 872,
+            "name": "Williams, Kent"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42855.jpg?s=3165af64d492c2000d5e16c366c4034d",
+            "language": "English",
+            "malId": 40701,
+            "name": "Snow, Derick"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/52187.jpg?s=a6c855c7791bab6389925214579e636e",
+            "language": "Spanish",
+            "malId": 52910,
+            "name": "Tomé, Jorge"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/157419.jpg?s=fe6bf8c76fc561c1ea79857adae33dec",
+        "malId": 58441,
+        "name": "Pagos",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/332409.jpg?s=b3580e0f7ff6eed25f41cfa31527bc48",
+        "malId": 151302,
+        "name": "de Chateau, Brianne",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67901.jpg?s=e174574d5b0cf847762ce98ffb62d5c9",
+            "language": "French",
+            "malId": 26385,
+            "name": "Vigne, Cécile"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/35511.jpg?s=954cdf3df3c49b251c75be4be0b814b6",
+            "language": "English",
+            "malId": 905,
+            "name": "Taylor, Veronica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/37647.jpg?s=8a9517a8077cf32107d2099f3116d5c4",
+            "language": "Italian",
+            "malId": 9991,
+            "name": "Atepi, Giuliana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/53885.jpg?s=ce302c0624f2250b2d10f1a4fefc6a3f",
+            "language": "Japanese",
+            "malId": 29165,
+            "name": "Kitagawa, Rina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/62737.jpg?s=a3ad5eba313bd6b168aabb24d3923105",
+            "language": "Portuguese (BR)",
+            "malId": 43628,
+            "name": "Ferreira, Priscila"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82430.jpg?s=3ad85ee14d4679494805e4e8660f522e",
+            "language": "Spanish",
+            "malId": 78988,
+            "name": "Peña, Laura"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/335914.jpg?s=cb73d46615b3be8d8d33328c267a8050",
+        "malId": 152800,
+        "name": "Cus",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/32907.jpg?s=61a42ba9fa26f9a009071c03e0c5b3e8",
+            "language": "German",
+            "malId": 31827,
+            "name": "Ihlenfeld, Heide"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46582.jpg?s=67d957143bf25381f76b098e31678244",
+            "language": "Italian",
+            "malId": 42840,
+            "name": "Maniglio, Giulia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/81602.jpg?s=85ac0c053c2b020b56bc0e3e27a241f1",
+            "language": "Portuguese (BR)",
+            "malId": 21185,
+            "name": "Paulita, Agatha"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33447.jpg?s=24f85e807a89d8a31d597a8d545848eb",
+            "language": "Japanese",
+            "malId": 56,
+            "name": "Konno, Hiromi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/34809.jpg?s=1c3379b3322880262fca475d33982d5a",
+            "language": "English",
+            "malId": 414,
+            "name": "Karbowski, Brittney"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67478.jpg?s=6bb457aaa9d4318c6d130d0daf0216ad",
+            "language": "French",
+            "malId": 30739,
+            "name": "Giraudon, Marie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67555.jpg?s=ae6c174253d284973e5e3a3df515694a",
+            "language": "Spanish",
+            "malId": 21455,
+            "name": "Barba, Liliana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/80655.jpg?s=1119dc06bfe1bb614a9530fda5b13504",
+            "language": "Portuguese (BR)",
+            "malId": 52907,
+            "name": "Evangelista, Mariana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82439.jpg?s=8530a3482a67a49979986deb7be72e25",
+            "language": "Spanish",
+            "malId": 78982,
+            "name": "Paredes, Numa"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/357368.jpg?s=fada9f83dc26e44e0fd6b4b619d95c5b",
+        "malId": 154838,
+        "name": "Cukatail",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/61216.jpg?s=5f7c7f76fedf9fa7b77457ab2c108068",
+            "language": "Portuguese (BR)",
+            "malId": 46009,
+            "name": "Volpato, Lipe"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/357383.jpg?s=d1516cad7d20e84c075e3f2999293702",
+        "malId": 154832,
+        "name": "Martinu",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78882.jpg?s=c16fa5640200e56fc9cca3ab54ba8fc1",
+            "language": "Portuguese (BR)",
+            "malId": 52877,
+            "name": "Ebling, Gabriel"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/357645.jpg?s=a5dd1e0405f28a2a54a231a6312604bf",
+        "malId": 161796,
+        "name": "Dercori",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/23949.jpg?s=92ad76a45f1797ff4bb42a2bc530a269",
+            "language": "Japanese",
+            "malId": 256,
+            "name": "Shindo, Naomi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/43584.jpg?s=b8b544d55e4b78efbee085785a2eb3dd",
+            "language": "English",
+            "malId": 36895,
+            "name": "Connors, Amber Lee"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63752.jpg?s=4528d52c93538e86093e8b6ecf716ea7",
+            "language": "Portuguese (BR)",
+            "malId": 11454,
+            "name": "Regina, Márcia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1568.jpg?s=0abf531c41a6ba408f8607f6d8cd2c2f",
+            "language": "Italian",
+            "malId": 1663,
+            "name": "Silvestri, Marcella"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73376.jpg?s=b0e339a66d5c1bcd0b492ed28a2aaf65",
+            "language": "Spanish",
+            "malId": 57229,
+            "name": "Edwards, Erica"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/357687.jpg?s=a84c2a9cccef0884ea4abee6f0df1ccf",
+        "malId": 161773,
+        "name": "Roas, Su",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/77023.jpg?s=6adb2b1bd856b67e7411e9bb5e203845",
+            "language": "Portuguese (BR)",
+            "malId": 53037,
+            "name": "Souza, Jacque"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/52550.jpg?s=7fb8dd3d4f519b1f538d3e20878051b0",
+            "language": "Hebrew",
+            "malId": 62723,
+            "name": "Cohen, Lin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/53699.jpg?s=892fcfca9c4c334de67492723bf0e219",
+            "language": "Japanese",
+            "malId": 8476,
+            "name": "Saitou, Yuka"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/65230.jpg?s=aea652529cd3dcf0b4915d8615641270",
+            "language": "Italian",
+            "malId": 55682,
+            "name": "Bonanomi, Giada"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67915.jpg?s=80e8a6be3847431e3b84b60ef60ec001",
+            "language": "French",
+            "malId": 1630,
+            "name": "Gabriele, Léa"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71299.jpg?s=799f4d3249ec390ef3c3117113095efd",
+            "language": "Spanish",
+            "malId": 56690,
+            "name": "Ugalde, Erika"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/72432.jpg?s=6f86c1c9b2e1b79fdf5d2b759148db66",
+            "language": "English",
+            "malId": 42318,
+            "name": "Rothrock, Kristi"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/357698.jpg?s=f5b7cd1d9dc362ef9dfdd67ebd40e138",
+        "malId": 161777,
+        "name": "Vikal",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/57708.jpg?s=14507772a7d4efb4741e0fbd7eedfafd",
+            "language": "Japanese",
+            "malId": 77,
+            "name": "Asano, Masumi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63539.jpg?s=4de8a9d8fef1e0377095058c81114b98",
+            "language": "English",
+            "malId": 7993,
+            "name": "Landa, Lauren"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/63251.jpg?s=e717416240591a1c54cb4c51b6366e0e",
+            "language": "Portuguese (BR)",
+            "malId": 52955,
+            "name": "Zampieri, Michelle"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/357701.jpg?s=029d06f2dab5fd6d728f42075d464907",
+        "malId": 161778,
+        "name": "Zirloin",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30935.jpg?s=df47c5bb3c7fc55fdc064357638fe218",
+            "language": "Portuguese (BR)",
+            "malId": 29167,
+            "name": "Camilo, Leonardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/52507.jpg?s=a459ed08aa24c17e7fc07d0b44726e56",
+            "language": "Japanese",
+            "malId": 47668,
+            "name": "Volcano Ota"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71801.jpg?s=ae27d4e55e29ead95db2664db4d309c5",
+            "language": "Spanish",
+            "malId": 62568,
+            "name": "Moreno, Héctor"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/72290.jpg?s=ef2644897920f71ed3f379c0bf7a257d",
+            "language": "English",
+            "malId": 10047,
+            "name": "Niosi, Chris"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/357959.jpg?s=d28197fa19a0c28c685e498c6e248657",
+        "malId": 2106,
+        "name": "Marron",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/24323.jpg?s=5e70ab7a22c401ccc0ad56b8619ab38c",
+            "language": "English",
+            "malId": 9526,
+            "name": "Ballard, Tia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/50308.jpg?s=d85c3b20097340b9142e54020756d532",
+            "language": "German",
+            "malId": 46575,
+            "name": "Okwuazu, Katie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/10319.jpg?s=3009df107dd7ca452146eb6d1ba82361",
+            "language": "Japanese",
+            "malId": 11362,
+            "name": "Ushida, Hiroko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/22015.jpg?s=aa5ab5b683e3aa4bb00305d20c270488",
+            "language": "Spanish",
+            "malId": 1846,
+            "name": "Hernández, Cristina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/61918.jpg?s=215d32379ebdaddb7e414b71180ba519",
+            "language": "Portuguese (BR)",
+            "malId": 1445,
+            "name": "Bullara, Fernanda"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/359110.jpg?s=58f17f2b7ba0b515900d54db2961b488",
+        "malId": 161812,
+        "name": "Hopp",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37197.jpg?s=175302f6dc5ab008a11c0d5c2423e4db",
+            "language": "Italian",
+            "malId": 25987,
+            "name": "Bertolas, Renata"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69517.jpg?s=212973610855fc099accf667a2883028",
+            "language": "Spanish",
+            "malId": 58174,
+            "name": "Flores, Kerygma"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/82939.jpg?s=674fd92137e2523bc6182252ea550d57",
+            "language": "Portuguese (BR)",
+            "malId": 52879,
+            "name": "Villaça, Renata"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/87352.jpg?s=24aff92eead1368b242b6b8afdb4339b",
+            "language": "Japanese",
+            "malId": 140,
+            "name": "Yukana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/53888.jpg?s=2cd6434cc055b68ff6db62530b228c88",
+            "language": "English",
+            "malId": 46291,
+            "name": "Gish, Amanda"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/359273.jpg?s=bbcd361b0c4197be821d8b0d483c4aac",
+        "malId": 161772,
+        "name": "Kahseral",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/83649.jpg?s=786c4319139f7280e4c8fc13ac926826",
+            "language": "English",
+            "malId": 19069,
+            "name": "Rinehart, Tyson"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/17135.jpg?s=5925123b8a7cf9b51a445c225442f0ef",
+            "language": "Japanese",
+            "malId": 357,
+            "name": "Ishizuka, Unshou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70681.jpg?s=d7778100f5505b9e77c9015dcc4102ea",
+            "language": "Spanish",
+            "malId": 57430,
+            "name": "Osorio, Dan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77477.jpg?s=3d23ccef3d344331658cb1474fbfeb09",
+            "language": "Portuguese (BR)",
+            "malId": 43704,
+            "name": "Azevedo, Fábio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/37903.jpg?s=b8e171cca99357736931653c551834ae",
+            "language": "Italian",
+            "malId": 1089,
+            "name": "Zucca, Mario"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78330.jpg?s=a4089abf0193a1c46838f4a8dcef2bdb",
+            "language": "French",
+            "malId": 18867,
+            "name": "Peter, Eric"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/381050.jpg?s=0208ef90b863d167661d75943022a695",
+        "malId": 161818,
+        "name": "Murisarm",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/70947.jpg?s=d598e52907f4c134ed4fda4b5565bc23",
+            "language": "English",
+            "malId": 60528,
+            "name": "Mai, Alex"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/82211.jpg?s=053b4e968b0be9e90fa60f1d93a07db9",
+            "language": "Spanish",
+            "malId": 78426,
+            "name": "Moreno, Pablo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/55933.jpg?s=8f707ff59c72240a5df190acced75e41",
+            "language": "Japanese",
+            "malId": 6145,
+            "name": "Naruse, Makoto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63177.jpg?s=c9011887bc42c8637c9b0e250dfca064",
+            "language": "Portuguese (BR)",
+            "malId": 46044,
+            "name": "Mendes, Vanderlan"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/443648.jpg?s=c361b6b6abc6d6f83534f015af8c5721",
+        "malId": 156762,
+        "name": "Referee",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/23823.jpg?s=367d5b5ea58455617bc31dfdee4f2a55",
+            "language": "English",
+            "malId": 8060,
+            "name": "Burnett, Chris"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/77287.jpg?s=3b4ce0bf39617a0ee54c659dcfcd0933",
+            "language": "Portuguese (BR)",
+            "malId": 43671,
+            "name": "Assali, Heitor"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/17731.jpg?s=d75d67d35cc91f3f32ffd8b1c573ffeb",
+            "language": "Japanese",
+            "malId": 738,
+            "name": "Tanaka, Kazunari"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/73804.jpg?s=c54d44a4ab05c807a865f8c4851a590f",
+            "language": "Spanish",
+            "malId": 5486,
+            "name": "Fortuny, Enzo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/11/46985.jpg?s=f7d24b418acbd197dc78cddd3e49a593",
+        "malId": 2551,
+        "name": "Son, Goten",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/1271.jpg?s=60ab2023c4d5bab2c3cbcb6f51882fcf",
+            "language": "Italian",
+            "malId": 1275,
+            "name": "Scianca, Patrizia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/16763.jpg?s=a3fe6153e19785538d6bf8bc090bc93b",
+            "language": "English",
+            "malId": 773,
+            "name": "Edwards, Kara"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/41159.jpg?s=c8a5754a2c486043a1b9d33be93bbd54",
+            "language": "German",
+            "malId": 40201,
+            "name": "Mann, Marcel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77340.jpg?s=2e78abe7d4d8d4fe06bc2e8bfb87fc0e",
+            "language": "Japanese",
+            "malId": 557,
+            "name": "Nozawa, Masako"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/27459.jpg?s=75949c01cc9ff34aef85f23a271bbab5",
+            "language": "Spanish",
+            "malId": 5682,
+            "name": "Torres, Laura"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/34225.jpg?s=a54556051335f6ca0f42df9f5f1108d9",
+            "language": "Portuguese (BR)",
+            "malId": 11518,
+            "name": "Noya, Fátima"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/40070.jpg?s=dbbede0acf7082d5c715bbd8703c2ca0",
+            "language": "English",
+            "malId": 406,
+            "name": "Sampler, Philece"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67476.jpg?s=ff50105bede34513c44198b231e6e6b1",
+            "language": "French",
+            "malId": 1613,
+            "name": "Lecordier, Brigitte"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/111836.jpg?s=83fa2b8e32ea4646fa7a2547d33bbfaa",
+        "malId": 9773,
+        "name": "Enma Dai-Ou",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/23983.jpg?s=2134950774012a629fd5ffd98a1ca084",
+            "language": "English",
+            "malId": 1342,
+            "name": "Rager, Chris"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/81573.jpg?s=fd67cce241e69b92a3bbd28596bd0202",
+            "language": "Portuguese (BR)",
+            "malId": 43825,
+            "name": "Porto, Paulo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/10127.jpg?s=50713fb59858af5a9668701332ee53b3",
+            "language": "Japanese",
+            "malId": 836,
+            "name": "Ootomo, Ryuuzaburou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/86115.jpg?s=8e5655088f0151f4968b0fa9049d0a3d",
+            "language": "German",
+            "malId": 87162,
+            "name": "Eckhardt, Hans-Eckart"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/254437.jpg?s=49e4aa493bf79fe5fee9ce4ee8f167c9",
+        "malId": 18068,
+        "name": "Kimidori, Aoi",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/275086.jpg?s=0d9b407e205627543b45d46a92206e05",
+        "malId": 2097,
+        "name": "Yajirobe",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/20827.jpg?s=bca4abc9c11fec12300a11e5902fc377",
+            "language": "Spanish",
+            "malId": 18367,
+            "name": "Ramirez, Luis Daniel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/6762.jpg?s=c7b1ee9ee01ac674474ff6547df4e1a8",
+            "language": "English",
+            "malId": 202,
+            "name": "McFarland, Mike"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70324.jpg?s=3f123300a3e33c79d4adc3c9e50cdeda",
+            "language": "Italian",
+            "malId": 42636,
+            "name": "Calatroni, Jacopo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73373.jpg?s=5f12d8c1574269f19104f2dfc9188ef2",
+            "language": "Japanese",
+            "malId": 75,
+            "name": "Tanaka, Mayumi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/81041.jpg?s=67cca1146c49222471cfbf7fc92e0a83",
+            "language": "Portuguese (BR)",
+            "malId": 5084,
+            "name": "Andreatto, Rodrigo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/311076.jpg?s=6ecb65c66b32f26c94ef185aca333c79",
+        "malId": 143896,
+        "name": "Gowasu",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/22439.jpg?s=4fe263718b51a49d5fcdf17d76d386df",
+            "language": "Italian",
+            "malId": 20262,
+            "name": "Corbetta, Oliviero"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/60375.jpg?s=78649c75663d7a15f2e26c9859c5ea9c",
+            "language": "Portuguese (BR)",
+            "malId": 43720,
+            "name": "de Castro, Fábio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/56025.jpg?s=456d2020afbc4fa0d353d6246c1ca13c",
+            "language": "Japanese",
+            "malId": 1358,
+            "name": "Gotou, Tetsuo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76912.jpg?s=11717702a1a653f0da2e2494b9cfaf85",
+            "language": "English",
+            "malId": 65333,
+            "name": "Schenck, Garrett"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/348954.jpg?s=5c7dbf7b62688a6bb8aea54b8596ad12",
+        "malId": 76348,
+        "name": "Beerus",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/22542.jpg?s=3b0eabce8d96b4a4ab0f772f70bc3aea",
+            "language": "Italian",
+            "malId": 1239,
+            "name": "Scattorin, Lorenzo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/41723.jpg?s=97ea2087cd6b2340d1b8fb506836912f",
+            "language": "English",
+            "malId": 956,
+            "name": "DeMita, John"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/64737.jpg?s=c0461c0a834ba255992d706b4d393dac",
+            "language": "Portuguese (BR)",
+            "malId": 25651,
+            "name": "Pissardini, Marcelo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65633.jpg?s=b41438b4520be37c95b9a6dbdf5bb8c3",
+            "language": "French",
+            "malId": 1025,
+            "name": "Magne, Bruno"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/37773.jpg?s=cdf3406e16b732c383c3b8ccc1a6fe0c",
+            "language": "English",
+            "malId": 39,
+            "name": "Douglas, Jason"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/73614.jpg?s=643eee95220ed1edde3cb796861fafec",
+            "language": "Japanese",
+            "malId": 11,
+            "name": "Yamadera, Kouichi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/11307.jpg?s=6c5463a53b0534febf17479ee970b065",
+            "language": "Hebrew",
+            "malId": 11997,
+            "name": "Yosefsberg, Yoram"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/33229.jpg?s=0887aadc2ed3e54e52d0f9930bf189b0",
+            "language": "German",
+            "malId": 23639,
+            "name": "Stritzel, Oliver"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68261.jpg?s=bd02ea7921caab6c99cdf0e3626e1962",
+            "language": "Spanish",
+            "malId": 57094,
+            "name": "Orozco, José Luis"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/357962.jpg?s=0655f3f041c046b45e5df8fa6599a09e",
+        "malId": 2111,
+        "name": "Videl",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/44905.jpg?s=9951235d6babb6c1c1ac9e6d4998316d",
+            "language": "French",
+            "malId": 24241,
+            "name": "Fauveau, Jennifer"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/82440.jpg?s=805fddeb87316f89cf9ec430a561ac7b",
+            "language": "Spanish",
+            "malId": 78981,
+            "name": "Hoyos, Mercedes"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/16763.jpg?s=a3fe6153e19785538d6bf8bc090bc93b",
+            "language": "English",
+            "malId": 773,
+            "name": "Edwards, Kara"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/37629.jpg?s=128445442faebb518b3a67d3e127d667",
+            "language": "Italian",
+            "malId": 9985,
+            "name": "Massironi, Cinzia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/56381.jpg?s=006be38deac7972dfd34701b71487c21",
+            "language": "Japanese",
+            "malId": 170,
+            "name": "Minaguchi, Yuko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58363.jpg?s=1bbbb9766ecde64a962866986df04a52",
+            "language": "English",
+            "malId": 21785,
+            "name": "Harlacher, Erika"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63755.jpg?s=881fad452b2323aedeef611763d76873",
+            "language": "Portuguese (BR)",
+            "malId": 8053,
+            "name": "Garcia, Melissa"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/32491.jpg?s=de6ed9e35fbb0e661a9c92f0f4763e9c",
+            "language": "German",
+            "malId": 31339,
+            "name": "Hönig, Maria"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68840.jpg?s=e5003c3aa927bafd54db7c5d359bcfb8",
+            "language": "Spanish",
+            "malId": 57475,
+            "name": "Vázquez, Carola"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/357971.jpg?s=9d41f38a348ce57f24c19b0e4dbed984",
+        "malId": 2094,
+        "name": "Gyumao",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/38702.jpg?s=4787dbfdcce1b482a18261660cb67956",
+            "language": "English",
+            "malId": 336,
+            "name": "Hebert, Kyle"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/10127.jpg?s=50713fb59858af5a9668701332ee53b3",
+            "language": "Japanese",
+            "malId": 836,
+            "name": "Ootomo, Ryuuzaburou"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/358436.jpg?s=4de1e1a134dc35affa231f917153cbe1",
+        "malId": 162237,
+        "name": "Super Shen Long",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "Italian",
+            "malId": 42944,
+            "name": "Bestoso, Vittorio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/10127.jpg?s=50713fb59858af5a9668701332ee53b3",
+            "language": "Japanese",
+            "malId": 836,
+            "name": "Ootomo, Ryuuzaburou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+            "language": "English",
+            "malId": 253,
+            "name": "Sabat, Christopher"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/359092.jpg?s=f0cee7f6cfa2cd1cb04e9ac1e1f3b0e0",
+        "malId": 154825,
+        "name": "Iwne",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/10693.jpg?s=28315ce100d61cbaecd8d29e120a5df5",
+            "language": "Japanese",
+            "malId": 9677,
+            "name": "Mamiya, Yasuhiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/60903.jpg?s=216667ada6db4bd9161e7fc4b32b7e59",
+            "language": "Portuguese (BR)",
+            "malId": 21343,
+            "name": "Guedes, Douglas"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/73207.jpg?s=90ae8079d86ecb381dc95417ec41257b",
+            "language": "German",
+            "malId": 45863,
+            "name": "Intorp, Christian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/39705.jpg?s=0fcd230e2577137533b2bd8bcafb42a7",
+            "language": "English",
+            "malId": 12025,
+            "name": "Martin, Josh"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78882.jpg?s=c16fa5640200e56fc9cca3ab54ba8fc1",
+            "language": "Portuguese (BR)",
+            "malId": 52877,
+            "name": "Ebling, Gabriel"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/359270.jpg?s=22735fe7aa014c20b7b9c76d629910a4",
+        "malId": 161780,
+        "name": "Hermila",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80260.jpg?s=3f019f86e26b5e129bddd1727e9756d0",
+            "language": "Portuguese (BR)",
+            "malId": 43874,
+            "name": "Araújo, Rodrigo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/88034.jpg?s=82dad37fd844ac0473d58f1e283e2cd1",
+            "language": "Japanese",
+            "malId": 1832,
+            "name": "Takatsuka, Masaya"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82886.jpg?s=1cb1e1ad07b766491ca9f587674a4b0b",
+            "language": "French",
+            "malId": 55488,
+            "name": "Rehlinger, Boris"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/359278.jpg?s=e8518deda5fcdc9616c298149ff5f5f9",
+        "malId": 154827,
+        "name": "Liquiir",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/60577.jpg?s=6941ed2cc768d097b0f3adfd0f42ea67",
+            "language": "English",
+            "malId": 41330,
+            "name": "Reid, Dallas"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/66160.jpg?s=31dc692d31e3fc8fb02e087bdbfc03ef",
+            "language": "Italian",
+            "malId": 55829,
+            "name": "Lomazzi, Edoardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/30941.jpg?s=8fd43261e3895c7d10ef4800ed45e4ac",
+            "language": "Spanish",
+            "malId": 18969,
+            "name": "Rivera, Benjamín"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58135.jpg?s=f0d78d8dd28abf06272c9d95dc16a21c",
+            "language": "Japanese",
+            "malId": 440,
+            "name": "Kishio, Daisuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71252.jpg?s=7a8455456d186cf2cce7119bd3d7c414",
+            "language": "French",
+            "malId": 9882,
+            "name": "Pascal, Benjamin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/74609.jpg?s=b448231b233f2c94ecaf2b1fb14d28c8",
+            "language": "Portuguese (BR)",
+            "malId": 44522,
+            "name": "Teles​, Ricardo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/359284.jpg?s=24dcafc4947cf1ccbaec5efba011d5dc",
+        "malId": 161823,
+        "name": "Obuni",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/64738.jpg?s=da0022ee2650a900c5aa32ec81cebdb3",
+            "language": "Portuguese (BR)",
+            "malId": 11869,
+            "name": "Soares, Renato"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68425.jpg?s=3f5cf66f52e7f6d9a6a302fdee7e92e4",
+            "language": "Spanish",
+            "malId": 57317,
+            "name": "Anaya, Raúl"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/56028.jpg?s=c3788a1f0d1c753c34a097aefed62b6a",
+            "language": "Japanese",
+            "malId": 9648,
+            "name": "Tani, Atsuki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82886.jpg?s=1cb1e1ad07b766491ca9f587674a4b0b",
+            "language": "French",
+            "malId": 55488,
+            "name": "Rehlinger, Boris"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/359295.jpg?s=fdbae9eae292e32718beae471df88208",
+        "malId": 161769,
+        "name": "Zoiray",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/32219.jpg?s=56388a04172eb662a43cc3798f5d2fd4",
+            "language": "Spanish",
+            "malId": 31335,
+            "name": "Ortiz, Mariana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/47511.jpg?s=b36ab3705ae3d95f325c4c68518cd69f",
+            "language": "English",
+            "malId": 254,
+            "name": "Dismuke, Aaron"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/59598.jpg?s=f88827b55134ca0140fac024ec9a2aff",
+            "language": "Portuguese (BR)",
+            "malId": 43860,
+            "name": "Dias, Bruno"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/57137.jpg?s=dcd648a00d69c253148e82e9eac56052",
+            "language": "Japanese",
+            "malId": 27495,
+            "name": "Morishita, Yukiko"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/12/361049.jpg?s=d8a00800fb8a53f503d868380e85a304",
+        "malId": 156759,
+        "name": "Fuwa's Attendant",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/66343.jpg?s=374b68e686dd463137f1715105e2d4f4",
+            "language": "Portuguese (BR)",
+            "malId": 47618,
+            "name": "Machado, Arthur"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/9314.jpg?s=f71df910cc292b3a3095a25844de5165",
+            "language": "Spanish",
+            "malId": 10729,
+            "name": "Strempler, Christian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/17731.jpg?s=d75d67d35cc91f3f32ffd8b1c573ffeb",
+            "language": "Japanese",
+            "malId": 738,
+            "name": "Tanaka, Kazunari"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/144257.jpg?s=5972d1bfd155fd96448231b5d1c69789",
+        "malId": 21344,
+        "name": "Daiou, Nikochan",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/302698.jpg?s=9e941747e46e2618cf33e7f6e394cc08",
+        "malId": 138959,
+        "name": "Hit",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/62790.jpg?s=08fb6675496541c6b1f30f00d31a8e7e",
+            "language": "Japanese",
+            "malId": 6755,
+            "name": "Yamaji, Kazuhiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/39513.jpg?s=7021f0f0da648285cee1549222163487",
+            "language": "English",
+            "malId": 14213,
+            "name": "Mercer, Matthew"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68499.jpg?s=1b8d362f26846c6f578167b713243e6e",
+            "language": "Spanish",
+            "malId": 13299,
+            "name": "Dutkiewicz, Idzi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68699.jpg?s=5bc6ee59a918cdae44ba1c913915e274",
+            "language": "Italian",
+            "malId": 42917,
+            "name": "Baldoin, Diego"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/75752.jpg?s=e8ea53371e7dfda0a2163edd6d9c6f86",
+            "language": "Portuguese (BR)",
+            "malId": 43800,
+            "name": "Júnior, Francisco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/86161.jpg?s=75bca0379f77857c35f518fd74e609f4",
+            "language": "Spanish",
+            "malId": 86864,
+            "name": "Seda, José Manuel"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/357657.jpg?s=b698abb5ee0c78546d5446a5e5674826",
+        "malId": 161786,
+        "name": "Katopesla",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/5206.jpg?s=de32e0b014809123b6dabe194f60422b",
+            "language": "Japanese",
+            "malId": 6506,
+            "name": "Oda, Yuusei"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/62827.jpg?s=f321af8faf546142dc7a0514a5341a01",
+            "language": "Portuguese (BR)",
+            "malId": 44428,
+            "name": "Rosa, Raul"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/39129.jpg?s=fe8b3e3eb8df64244476478515603201",
+            "language": "English",
+            "malId": 36973,
+            "name": "Storms, Garret"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78330.jpg?s=a4089abf0193a1c46838f4a8dcef2bdb",
+            "language": "French",
+            "malId": 18867,
+            "name": "Peter, Eric"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/357660.jpg?s=857f336e73c6b25846201c62d41edc22",
+        "malId": 161781,
+        "name": "Ku, Sanka",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37197.jpg?s=175302f6dc5ab008a11c0d5c2423e4db",
+            "language": "Italian",
+            "malId": 25987,
+            "name": "Bertolas, Renata"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/73445.jpg?s=f60764cf102eb6ef6e6f64684018ea40",
+            "language": "Spanish",
+            "malId": 57204,
+            "name": "Jara, Betzabé"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/79722.jpg?s=628a806476e40830dde7799f2d3ac39d",
+            "language": "Portuguese (BR)",
+            "malId": 14481,
+            "name": "Bortoletto, Leticia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68031.jpg?s=3d4e00b97ff97695c36a1e95d59498fd",
+            "language": "Japanese",
+            "malId": 348,
+            "name": "Shiraishi, Ryouko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68630.jpg?s=ca4f56989c47a53e25e7625342b09d26",
+            "language": "French",
+            "malId": 57588,
+            "name": "Billault, Christèle"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/85798.jpg?s=cbd020ffd802ad6514f19a92c3ba2874",
+            "language": "Korean",
+            "malId": 86355,
+            "name": "Song, Ha-rim"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48585.jpg?s=4ab628c4e3f797d0c4ecfe261eb32ddb",
+            "language": "English",
+            "malId": 38451,
+            "name": "Berry, Morgan"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/357664.jpg?s=fa6b6dadcf5ae098de9b3ee71194cc2f",
+        "malId": 161767,
+        "name": "Kunshi",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65561.jpg?s=f06a9cd2984bebc086b7fe35770daa3d",
+            "language": "Japanese",
+            "malId": 205,
+            "name": "Morita, Masakazu"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68397.jpg?s=b64c3133609bd36e6cb2e2ab02bfc904",
+            "language": "Spanish",
+            "malId": 57252,
+            "name": "Cervantes, Enrique"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80216.jpg?s=f2d29198316bac69ca2dcfb398ec8239",
+            "language": "English",
+            "malId": 74003,
+            "name": "Long, Chris"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67963.jpg?s=a6379a67c1d9f40bdf6a4d2b72f7f8cc",
+            "language": "Portuguese (BR)",
+            "malId": 36892,
+            "name": "Caodaglio, Marcelo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/357670.jpg?s=b3e27121812b57f05a3a33b05b5e2eba",
+        "malId": 161798,
+        "name": "Monna",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/81098.jpg?s=240ccea3412784ae9ae4440d2effd6ea",
+            "language": "French",
+            "malId": 76037,
+            "name": "Bodin, Emmanuelle"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/50825.jpg?s=a4192420c46fd4cabba70b4587c2a68b",
+            "language": "English",
+            "malId": 46946,
+            "name": "Fajardo, Emily"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/85851.jpg?s=71b40940222ef118386af6a5425fd6c1",
+            "language": "Korean",
+            "malId": 86436,
+            "name": "Son, Seon-yeong"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/9251.jpg?s=2a6fbd7b83b94cb4a70a123842de4d05",
+            "language": "German",
+            "malId": 10696,
+            "name": "Schmitz, Tanja"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/61735.jpg?s=95475ab6902ffc431f25af811ccf1971",
+            "language": "Portuguese (BR)",
+            "malId": 52921,
+            "name": "Ramalho, Karen"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76439.jpg?s=be21db0406c9fe697e00c58fe6297be7",
+            "language": "Japanese",
+            "malId": 496,
+            "name": "Yamazaki, Wakana"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/357864.jpg?s=eb45b418c08d3856616b52589035de2d",
+        "malId": 131070,
+        "name": "Karoni",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/15961.jpg?s=bf1456503e17c34dd414d3e9478fde64",
+            "language": "English",
+            "malId": 251,
+            "name": "Burgmeier, John"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/17219.jpg?s=7fa6c270b98c6fbc446c2af28acf3458",
+            "language": "Japanese",
+            "malId": 10063,
+            "name": "Fujimoto, Takahiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/78102.jpg?s=ef2bbdfd265e16a813ec4bb5781494e5",
+            "language": "Portuguese (BR)",
+            "malId": 43859,
+            "name": "Morales, Alex"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/26677.jpg?s=976e046a143e5671c37c143b76559abe",
+            "language": "German",
+            "malId": 23795,
+            "name": "Jacob, Sebastian"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/358049.jpg?s=e80798b5c21ec9032ce7ea2d044723cb",
+        "malId": 2133,
+        "name": "Shuu",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/35241.jpg?s=19e85bfc90e0bf27357ca77268c82bf1",
+            "language": "Portuguese (BR)",
+            "malId": 34419,
+            "name": "Costha, Faduli"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37131.jpg?s=c23880d991ef893051b99c68153594b6",
+            "language": "Italian",
+            "malId": 9534,
+            "name": "Balzarotti, Marco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69790.jpg?s=590f8695b97c595bfb32380b6156fbcc",
+            "language": "French",
+            "malId": 56660,
+            "name": "Marais, Stéphane"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/19749.jpg?s=0e65042064237840447a4855571a871f",
+            "language": "English",
+            "malId": 1138,
+            "name": "Cason, Chris"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/40358.jpg?s=9d4c32af01e0b359183767658bbb4915",
+            "language": "German",
+            "malId": 10706,
+            "name": "Petrick, Dirk"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47113.jpg?s=feae1bb33be3f2958c0f6a487dfcccff",
+            "language": "Portuguese (BR)",
+            "malId": 43723,
+            "name": "Loy, João"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47808.jpg?s=024fa58b11da87371df0bbe641ed3c33",
+            "language": "Spanish",
+            "malId": 44343,
+            "name": "Leal, Miguel Ángel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/49955.jpg?s=49f5613329a1fab1ee4810d37ae4a284",
+            "language": "English",
+            "malId": 36627,
+            "name": "Arciniega, Tommy"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/87617.jpg?s=c626dd4a60d6b5f773fa0c052f5c9455",
+            "language": "Japanese",
+            "malId": 761,
+            "name": "Genda, Tesshou"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/358753.jpg?s=22e0021c5c8151ddf0816b8d0a7966c1",
+        "malId": 54801,
+        "name": "Dr. Mashirito",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/73946.jpg?s=f263a3c5db790f1ff5fe5acbc8b51dad",
+            "language": "Spanish",
+            "malId": 64181,
+            "name": "López, Joaquín"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/37157.jpg?s=37ac121dd5f6b4265263f43015e3be40",
+            "language": "Italian",
+            "malId": 1289,
+            "name": "Moneta, Claudio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/80436.jpg?s=db6e64580a47c97e72876df5c4912f4d",
+            "language": "Japanese",
+            "malId": 177,
+            "name": "Okiayu, Ryoutarou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/80446.jpg?s=e0b4acc606a2a795d768758184454af4",
+            "language": "Portuguese (BR)",
+            "malId": 11695,
+            "name": "Moura, Fábio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/88682.jpg?s=291b49cb5175ffaa307ef5663cede22c",
+            "language": "English",
+            "malId": 5431,
+            "name": "Yandell, Barry"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/358997.jpg?s=ad53b1930a7c24074b0a29676345c55c",
+        "malId": 150753,
+        "name": "Caulifla",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/47023.jpg?s=509e180d5d609cf530df628ad05de163",
+            "language": "Italian",
+            "malId": 43315,
+            "name": "Francese, Chiara"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68312.jpg?s=9423543c02840f0a8cfa913a7e2e781e",
+            "language": "Spanish",
+            "malId": 57224,
+            "name": "Orozco, Andrea"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69924.jpg?s=3beaf1bce9580137c405bfe60ccc93bc",
+            "language": "Portuguese (BR)",
+            "malId": 11403,
+            "name": "Paulita, Flora"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/11910.jpg?s=598c7b02bdcfe072b19d8b67646121f4",
+            "language": "German",
+            "malId": 6135,
+            "name": "Oeffinger, Marieke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/49242.jpg?s=7a7f209e6414f65664f03d8207372870",
+            "language": "English",
+            "malId": 30375,
+            "name": "Maxwell, Elizabeth"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/54465.jpg?s=93788ed7d901254bf1cd9a7dbcfd7a33",
+            "language": "Japanese",
+            "malId": 9858,
+            "name": "Komatsu, Yuka"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67793.jpg?s=47b1524e57c6376a3f7470a44a002dfe",
+            "language": "French",
+            "malId": 30743,
+            "name": "Leroux, Marianne"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/359025.jpg?s=8e74451e18ae4b619daf5187e49035fe",
+        "malId": 151307,
+        "name": "Kale",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/25963.jpg?s=1fa9c097ae8f09f03bf8f4e124468e0b",
+            "language": "Spanish",
+            "malId": 22589,
+            "name": "Leal, Lupita"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/43957.jpg?s=09918392e6942711f21a261b48c7c3f5",
+            "language": "English",
+            "malId": 38428,
+            "name": "Bennett, Dawn M."
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/5027.jpg?s=fc36741213a285e501f60fbce5fe752c",
+            "language": "Hungarian",
+            "malId": 7771,
+            "name": "Czető, Zsanett"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67175.jpg?s=9b46a1dffbb23027560211a2e552b00b",
+            "language": "French",
+            "malId": 56436,
+            "name": "Virtudes, Brigitte"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67699.jpg?s=02f151c2636d43d14f645a9daf72860b",
+            "language": "Italian",
+            "malId": 46525,
+            "name": "Bersani, Giulia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/52550.jpg?s=7fb8dd3d4f519b1f538d3e20878051b0",
+            "language": "Hebrew",
+            "malId": 62723,
+            "name": "Cohen, Lin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/87352.jpg?s=24aff92eead1368b242b6b8afdb4339b",
+            "language": "Japanese",
+            "malId": 140,
+            "name": "Yukana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73129.jpg?s=dfa67b1cdeb0b8c6162a5809ef6908c5",
+            "language": "Portuguese (BR)",
+            "malId": 5178,
+            "name": "Fernandes, Samira"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/86151.jpg?s=1124f8c43f7cf73d6e9db46933a3aa35",
+            "language": "Spanish",
+            "malId": 86863,
+            "name": "Peña, Cristina"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/359282.jpg?s=bef1dcc1f5d8f53d7d8a3bbe7f7c7d88",
+        "malId": 154840,
+        "name": "Mojito",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77184.jpg?s=f34daec5adafcc191a942ab6d3a2d69d",
+            "language": "Portuguese (BR)",
+            "malId": 52876,
+            "name": "Cruz, Alexandre"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/50057.jpg?s=56cb349cd63bff3b68c6d32eeedf25e6",
+            "language": "English",
+            "malId": 43095,
+            "name": "Wang, Howard"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71058.jpg?s=69078b11ad0b9cb3c62a2981b85dff34",
+            "language": "Spanish",
+            "malId": 28309,
+            "name": "Mora, Moisés Iván"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76155.jpg?s=9a30973e8b9a40a1fbd4d6cf0b20d790",
+            "language": "Japanese",
+            "malId": 112,
+            "name": "Midorikawa, Hikaru"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/359289.jpg?s=42b0217c4e9c6d844d3003e72af7c341",
+        "malId": 161797,
+        "name": "Shosa",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70855.jpg?s=cb2012c44fe9d197e983b3fa200eec97",
+            "language": "Spanish",
+            "malId": 56735,
+            "name": "Mayén, Alejandro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77184.jpg?s=f34daec5adafcc191a942ab6d3a2d69d",
+            "language": "Portuguese (BR)",
+            "malId": 52876,
+            "name": "Cruz, Alexandre"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/88034.jpg?s=82dad37fd844ac0473d58f1e283e2cd1",
+            "language": "Japanese",
+            "malId": 1832,
+            "name": "Takatsuka, Masaya"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/361040.jpg?s=357e5b68800472f9820d8555762dfd32",
+        "malId": 163386,
+        "name": "Khai",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/42965.jpg?s=2419dbadc45b8cf0fe17e22c7b524d4e",
+            "language": "English",
+            "malId": 19283,
+            "name": "Roberts, Aaron"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71357.jpg?s=5b145425b3bfb8d5f24acc659c152f25",
+            "language": "Japanese",
+            "malId": 12705,
+            "name": "Murata, Taishi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/79735.jpg?s=f0c97a1d03a2439c1836e8cff75dbc73",
+            "language": "Portuguese (BR)",
+            "malId": 43670,
+            "name": "Gama, Lucas"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/72010.jpg?s=5deb8bf4f428638ef57c2ac3e45277b3",
+            "language": "French",
+            "malId": 55020,
+            "name": "Borg, Yoann"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/383100.jpg?s=d08470fe4876d9ead28b3e13ab7baaeb",
+        "malId": 3183,
+        "name": "Norimaki, Senbei",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69790.jpg?s=590f8695b97c595bfb32380b6156fbcc",
+            "language": "French",
+            "malId": 56660,
+            "name": "Marais, Stéphane"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/23393.jpg?s=bb80548212ab0bbf4009dc989fa90544",
+            "language": "English",
+            "malId": 480,
+            "name": "Elliott, R. Bruce"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/32675.jpg?s=9c7a25e1a78409e7f0621cc8b973880f",
+            "language": "Japanese",
+            "malId": 5770,
+            "name": "Yara, Yuusaku"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/77182.jpg?s=81a88728d5a308fb4147186c6a3ac248",
+            "language": "Portuguese (BR)",
+            "malId": 55775,
+            "name": "César, Rogério"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/45233.jpg?s=0b89953905c3c875d769703961ef47a9",
+        "malId": 9784,
+        "name": "Gregory",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "Italian",
+            "malId": 43441,
+            "name": "Dalla Valle, Stefano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/15961.jpg?s=bf1456503e17c34dd414d3e9478fde64",
+            "language": "English",
+            "malId": 251,
+            "name": "Burgmeier, John"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/60903.jpg?s=216667ada6db4bd9161e7fc4b32b7e59",
+            "language": "Portuguese (BR)",
+            "malId": 21343,
+            "name": "Guedes, Douglas"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33097.jpg?s=66e8122478b63ad39225f1e669015277",
+            "language": "Japanese",
+            "malId": 7631,
+            "name": "Numata, Yusuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66341.jpg?s=b338477aa6ea951fa2e6e3656ffe3160",
+            "language": "Portuguese (BR)",
+            "malId": 44017,
+            "name": "Ferreira, Matheus"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/24639.jpg?s=a5602f2f8b05a85abd8793ee1a41e71b",
+            "language": "Spanish",
+            "malId": 21469,
+            "name": "Lezama, Ernesto"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/496535.jpg?s=b231f5bc1cdd00b91ee2fea142ee5844",
+        "malId": 76346,
+        "name": "Whis",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65561.jpg?s=f06a9cd2984bebc086b7fe35770daa3d",
+            "language": "Japanese",
+            "malId": 205,
+            "name": "Morita, Masakazu"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/87573.jpg?s=5cc2c408b482daa7c85de9e566a437bf",
+            "language": "English",
+            "malId": 1547,
+            "name": "Erholtz, Doug"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/38035.jpg?s=ed5d7c163e5f5c9aa59816028580f4a0",
+            "language": "English",
+            "malId": 9087,
+            "name": "Sinclair, Ian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46493.jpg?s=f7121c21048f736d3a27c1c099485371",
+            "language": "Italian",
+            "malId": 42998,
+            "name": "Zurla, Alessandro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/50307.jpg?s=b320f893aed9f5b8033b345cc399dc60",
+            "language": "German",
+            "malId": 46574,
+            "name": "Feld, Oliver"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/5596.jpg?s=67e6781749b8c000b49a0ac13c1fb9d0",
+            "language": "Hungarian",
+            "malId": 8391,
+            "name": "Kisfalusi, Lehel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/63933.jpg?s=f8fa76f515b437bd2918631f4fdf349d",
+            "language": "Spanish",
+            "malId": 22179,
+            "name": "Castañeda, Arturo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67076.jpg?s=c084c71363995383e5553ca6b31dfc54",
+            "language": "Portuguese (BR)",
+            "malId": 25653,
+            "name": "Grinnan, Felipe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71215.jpg?s=d026f555c1f32ca45dcf372927d6d6d6",
+            "language": "French",
+            "malId": 24293,
+            "name": "Méyère, Bruno"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/13/52822.jpg?s=6e11379dc260224463bcb0990d4cbd1c",
+        "malId": 2151,
+        "name": "Chaozu",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/22019.jpg?s=01f3c0c0edbd17731493d369a563bb01",
+            "language": "Spanish",
+            "malId": 5029,
+            "name": "Acevedo, Patricia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/26915.jpg?s=0ea5349cc9527223f5c407c80903951e",
+            "language": "Japanese",
+            "malId": 8760,
+            "name": "Emori, Hiroko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/48137.jpg?s=ab0f807588ec019cb989097b85ed0601",
+            "language": "English",
+            "malId": 659,
+            "name": "Palencia, Brina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1283.jpg?s=58fe797c8fc4b60dc11aab8cc74dce62",
+            "language": "Italian",
+            "malId": 1291,
+            "name": "Valenti, Federica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/35945.jpg?s=68f686f1c489e9054f0c4a8357822ff2",
+            "language": "German",
+            "malId": 33585,
+            "name": "Blankenburg, Julia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/61222.jpg?s=56480c6e6283f5833eac72fa85e280f9",
+            "language": "Portuguese (BR)",
+            "malId": 8241,
+            "name": "Bezerra, Úrsula"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/126147.jpg?s=c6b311761d167c90d6717a7555efc3ae",
+        "malId": 4014,
+        "name": "Yamcha",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/21749.jpg?s=a4af5167c2fc4c7cca1fb48650a06612",
+            "language": "Italian",
+            "malId": 1236,
+            "name": "Sabre, Diego"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30181.jpg?s=d5dd30d9e92386e9f8d26770b8ccb838",
+            "language": "French",
+            "malId": 1150,
+            "name": "Legrand, Eric"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48362.jpg?s=3dc58f412bef7e41d0f82a8f2874e3f7",
+            "language": "English",
+            "malId": 1072,
+            "name": "George, Grant"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/8072.jpg?s=f4cbad7fc94e4e714d9a0e0388b955e2",
+            "language": "Spanish",
+            "malId": 10019,
+            "name": "Mendoza, Ricardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/11155.jpg?s=4c1dabbbcb88128d8cb5ce7bc0c086c6",
+            "language": "German",
+            "malId": 11916,
+            "name": "Hackenberger, Karlo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/65061.jpg?s=ee95a10b9ad71e8b9f6e870f032e72a6",
+            "language": "Japanese",
+            "malId": 326,
+            "name": "Furuya, Toru"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/65998.jpg?s=2e7f1148a0f5055c18264c877285fa3f",
+            "language": "Portuguese (BR)",
+            "malId": 8609,
+            "name": "Araújo, Márcio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+            "language": "English",
+            "malId": 253,
+            "name": "Sabat, Christopher"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/247963.jpg?s=f4b64bc7b901fd59d3d9fd6b42afcf1c",
+        "malId": 2102,
+        "name": "Chi-Chi",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/22019.jpg?s=01f3c0c0edbd17731493d369a563bb01",
+            "language": "Spanish",
+            "malId": 5029,
+            "name": "Acevedo, Patricia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/14799.jpg?s=3ae22fff134b50892a53bd7c2d51796e",
+            "language": "English",
+            "malId": 85,
+            "name": "Ruff, Michelle"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/65060.jpg?s=022b1f040c3747d60e958abd5252a1df",
+            "language": "Japanese",
+            "malId": 674,
+            "name": "Watanabe, Naoko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/21889.jpg?s=cda2467d74b5663a3d332f0a57c63b85",
+            "language": "German",
+            "malId": 7109,
+            "name": "Weiß, Jennifer"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/33925.jpg?s=1b6098ec439c2c06c01fa0ebe8a0e481",
+            "language": "Italian",
+            "malId": 1280,
+            "name": "Spinelli, Elisabetta"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/34425.jpg?s=d302b6ddb0749ece96164ee6b2800582",
+            "language": "Portuguese (BR)",
+            "malId": 11453,
+            "name": "Marinho, Raquel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/39428.jpg?s=4bb838a3e7e1f5633a873c40da869963",
+            "language": "English",
+            "malId": 851,
+            "name": "Cranz, Cynthia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85888.jpg?s=ebae3e39389e043b9ee26c27081fc4c5",
+            "language": "French",
+            "malId": 56315,
+            "name": "Hautbois, Anouck"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/280893.jpg?s=2b0fdc4d608cdb9f6ca28d6192cb9251",
+        "malId": 678,
+        "name": "Bulma",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/24249.jpg?s=683c99ba6b0f35b36a08c906516394dd",
+            "language": "Japanese",
+            "malId": 354,
+            "name": "Tsuru, Hiromi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/35525.jpg?s=56430e22aa50b74003bd1377fcefec57",
+            "language": "English",
+            "malId": 36,
+            "name": "Lee, Wendee"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/52185.jpg?s=643001397550c72f3ef2795d806a3564",
+            "language": "Spanish",
+            "malId": 52911,
+            "name": "De la Gala, Nonia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/37923.jpg?s=404223ca84c96f83d491f45acf82eb10",
+            "language": "English",
+            "malId": 159,
+            "name": "Rial, Monica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/81922.jpg?s=26e73d115ebbffbd3504b5c8992988b9",
+            "language": "Spanish",
+            "malId": 13307,
+            "name": "Garcel, Rocío"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/28987.jpg?s=5c2fd7a61117beb4b7351f572bb5a52a",
+            "language": "Italian",
+            "malId": 1090,
+            "name": "Pacotto, Emanuela"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/34247.jpg?s=a6a4ffccf7b81b8e47046a6f88d49699",
+            "language": "Portuguese (BR)",
+            "malId": 11402,
+            "name": "Gaidarji, Tânia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/34481.jpg?s=de9c14da74b15c52c132d78273613acd",
+            "language": "German",
+            "malId": 33579,
+            "name": "Katt, Carmen"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/72178.jpg?s=b2210df846b5d57573a2cf2e09fb679a",
+            "language": "French",
+            "malId": 20448,
+            "name": "Monsarrat, Céline"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/321997.jpg?s=1180eb4bcafb0bafbc9a118f5f19ea52",
+        "malId": 146840,
+        "name": "Geppuman",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/17323.jpg?s=31e73a6fc1a9e86dd9b460880c70fb9a",
+            "language": "Japanese",
+            "malId": 6241,
+            "name": "Masutani, Yasunori"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/29839.jpg?s=7f78b7ef7ec6f46d1c8e68931766a808",
+            "language": "English",
+            "malId": 43,
+            "name": "Mignogna, Vic"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/77324.jpg?s=7cb24b19355ebfa289d06498f9711fb6",
+            "language": "Portuguese (BR)",
+            "malId": 43693,
+            "name": "Silva, Dláigelles"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/350541.jpg?s=bbb2534813f12ea7df06cd3016669952",
+        "malId": 156587,
+        "name": "Haru",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/64826.jpg?s=04f26460a39451e2e17686762e6b2a2f",
+            "language": "Japanese",
+            "malId": 11162,
+            "name": "Fujii, Yukiyo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71053.jpg?s=fd998a8ec738f6bf53d7d8c9a2e40da7",
+            "language": "German",
+            "malId": 60693,
+            "name": "Flechtner, Derya"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80600.jpg?s=242d4f91d647eccf9d97a0d313c1ca45",
+            "language": "English",
+            "malId": 8686,
+            "name": "Solusod, Micah"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/37621.jpg?s=29458b78ca0b08d825b9470dddc56f77",
+            "language": "Italian",
+            "malId": 35769,
+            "name": "Morese, Deborah"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/79361.jpg?s=ef28eff7e0907a36884f8f7519ef087a",
+            "language": "Portuguese (BR)",
+            "malId": 45410,
+            "name": "Martins, Gabriel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67476.jpg?s=ff50105bede34513c44198b231e6e6b1",
+            "language": "French",
+            "malId": 1613,
+            "name": "Lecordier, Brigitte"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/70798.jpg?s=d116e74afb0bb56148797e65a36855eb",
+            "language": "Spanish",
+            "malId": 52919,
+            "name": "Rojas, Annie"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/357374.jpg?s=a0f4a60f67f3dcda4dabee173baac1e9",
+        "malId": 154836,
+        "name": "Sour",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/47866.jpg?s=63b5532e948ce28a1e7c7e1554929a9f",
+            "language": "Spanish",
+            "malId": 44398,
+            "name": "Velázquez, Alan Fernando"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46121.jpg?s=e8e5e8e9afcdbfe9367310a1d4c1e845",
+            "language": "Italian",
+            "malId": 42556,
+            "name": "Balbi, Marco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67473.jpg?s=71d73804982865747e96680debef8e5f",
+            "language": "Portuguese (BR)",
+            "malId": 40349,
+            "name": "Rufino, Sérgio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/81901.jpg?s=56614a9ba88aa70a7ba0451f37d9bc0c",
+            "language": "English",
+            "malId": 16641,
+            "name": "Tindle, Austin"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/357684.jpg?s=3b494569ac9ce375804c12f3d4f737c3",
+        "malId": 161779,
+        "name": "Prum",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67494.jpg?s=45a31cbddbeef723c8a3ce90d6041465",
+            "language": "French",
+            "malId": 56644,
+            "name": "Atlan, Jean-Luc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/10862.jpg?s=cff5bf6118c8b109868c0ce3b3d8db13",
+            "language": "Japanese",
+            "malId": 257,
+            "name": "Hiyama, Nobuyuki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69942.jpg?s=ce99ec2d05e31d9f1e42947333f7ef69",
+            "language": "Spanish",
+            "malId": 58398,
+            "name": "Vélez, Humberto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48314.jpg?s=3fdefad6f93960454c1e2374990022c8",
+            "language": "Portuguese (BR)",
+            "malId": 44427,
+            "name": "Rodrigues, Zeca"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/357688.jpg?s=1b5af5c8a19da5ca74743912a9cae40f",
+        "malId": 161807,
+        "name": "Rozel",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/10693.jpg?s=28315ce100d61cbaecd8d29e120a5df5",
+            "language": "Japanese",
+            "malId": 9677,
+            "name": "Mamiya, Yasuhiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/49017.jpg?s=4cde639f89c2e6dbfcfa0aeea68437fe",
+            "language": "German",
+            "malId": 45566,
+            "name": "Simpson, Dirc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67963.jpg?s=a6379a67c1d9f40bdf6a4d2b72f7f8cc",
+            "language": "Portuguese (BR)",
+            "malId": 36892,
+            "name": "Caodaglio, Marcelo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/357690.jpg?s=ddcb0d678564db4b960b90c8fa165639",
+        "malId": 161821,
+        "name": "Rubalt",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/10693.jpg?s=28315ce100d61cbaecd8d29e120a5df5",
+            "language": "Japanese",
+            "malId": 9677,
+            "name": "Mamiya, Yasuhiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65720.jpg?s=4295ec2c25f697f9717caad22a299818",
+            "language": "French",
+            "malId": 55541,
+            "name": "Melennec, Patrice"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80260.jpg?s=3f019f86e26b5e129bddd1727e9756d0",
+            "language": "Portuguese (BR)",
+            "malId": 43874,
+            "name": "Araújo, Rodrigo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/361037.jpg?s=82ac06c6b49427c6b59d1f275a7ca078",
+        "malId": 163383,
+        "name": "Fuwa",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/17323.jpg?s=31e73a6fc1a9e86dd9b460880c70fb9a",
+            "language": "Japanese",
+            "malId": 6241,
+            "name": "Masutani, Yasunori"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68790.jpg?s=99886885c31d645f6f0b608e4a4ee3b3",
+            "language": "Spanish",
+            "malId": 57435,
+            "name": "Abundis, Daniel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/40009.jpg?s=dac44b70ffb7c4412e83bed9edb7c31e",
+            "language": "English",
+            "malId": 14477,
+            "name": "Lush, Gregory"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/46449.jpg?s=245a243cd5cf66f9ab01914721506a2a",
+            "language": "Italian",
+            "malId": 42979,
+            "name": "Germano, Alessandro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/77324.jpg?s=7cb24b19355ebfa289d06498f9711fb6",
+            "language": "Portuguese (BR)",
+            "malId": 43693,
+            "name": "Silva, Dláigelles"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/14/86185.jpg?s=145f25d852734f70db55a92cab54b27b",
+        "malId": 913,
+        "name": "Vegeta",
+        "role": "Main",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30181.jpg?s=d5dd30d9e92386e9f8d26770b8ccb838",
+            "language": "French",
+            "malId": 1150,
+            "name": "Legrand, Eric"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37125.jpg?s=3a1e02f697e98262309bca2797d0575e",
+            "language": "Italian",
+            "malId": 1087,
+            "name": "Iacono, Gianluca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69407.jpg?s=51707e9cb717cf2dbd46b261f5ab5f0c",
+            "language": "Spanish",
+            "malId": 1698,
+            "name": "García, René"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80498.jpg?s=9a32ee02710cc4c72006b683add1c312",
+            "language": "English",
+            "malId": 37957,
+            "name": "Briner, Justin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/15759.jpg?s=9338f6a3db14b2e031e5f2c2681ccbd4",
+            "language": "Korean",
+            "malId": 14819,
+            "name": "Kim, Seung jun"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/26301.jpg?s=41a461909be9dc569e78d0acbd78289f",
+            "language": "German",
+            "malId": 22921,
+            "name": "Hoffmann, Florian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47113.jpg?s=feae1bb33be3f2958c0f6a487dfcccff",
+            "language": "Portuguese (BR)",
+            "malId": 43723,
+            "name": "Loy, João"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/5026.jpg?s=4f59f87ae59696867902174412477773",
+            "language": "Hungarian",
+            "malId": 7769,
+            "name": "Czető, Roland"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/50611.jpg?s=3465f2d57eabc011d155724dd1b8f813",
+            "language": "Spanish",
+            "malId": 46818,
+            "name": "Hidalgo, Alberto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63540.jpg?s=4c43ddaf76aaa0d34205a2411096f13c",
+            "language": "Japanese",
+            "malId": 518,
+            "name": "Horikawa, Ryo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80557.jpg?s=9d3c976552d057e1d913616c118983c6",
+            "language": "English",
+            "malId": 8491,
+            "name": "Tang, Kaiji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/11246.jpg?s=744c2a1513243ffd302809e5086fe736",
+            "language": "Hebrew",
+            "malId": 11970,
+            "name": "Mendelman, Ami"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+            "language": "English",
+            "malId": 253,
+            "name": "Sabat, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/75283.jpg?s=c0d6eb2cf256f863d329beb4b43ad502",
+            "language": "Portuguese (BR)",
+            "malId": 46008,
+            "name": "Zink, Ma"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79734.jpg?s=9de7362478bc71a1eadbf32f7d249737",
+            "language": "Portuguese (BR)",
+            "malId": 7350,
+            "name": "Rollo, Alfredo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85386.jpg?s=64e9e78aa21e52d8e4e696faf728700b",
+            "language": "Spanish",
+            "malId": 85639,
+            "name": "Prieto, Paco"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/255611.jpg?s=39dc385b86011af2e04f37b9179fd359",
+        "malId": 111405,
+        "name": "Soramame, Kurikinton",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/329542.jpg?s=4e5dd74c25cc9db1ac3b9349d84b4aa9",
+        "malId": 150835,
+        "name": "Renso",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/72858.jpg?s=b3f1e037fe7e4c0af2eecc6aafceee6e",
+            "language": "Spanish",
+            "malId": 62365,
+            "name": "Solo, Raúl"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/49059.jpg?s=fcf990550277eb072e46e353e3a1f7ea",
+            "language": "German",
+            "malId": 45603,
+            "name": "Lelle, Tobias"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71391.jpg?s=33f2104ee933745f29f10e0fb6a744ba",
+            "language": "English",
+            "malId": 16645,
+            "name": "Pearlman, Randy"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71392.jpg?s=cd257aa17be7d403c69266bb6045d127",
+            "language": "Portuguese (BR)",
+            "malId": 43709,
+            "name": "Marques, Guilherme"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/88034.jpg?s=82dad37fd844ac0473d58f1e283e2cd1",
+            "language": "Japanese",
+            "malId": 1832,
+            "name": "Takatsuka, Masaya"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/357388.jpg?s=bf6ff7edca3f6fb36f94eea464a57656",
+        "malId": 154826,
+        "name": "Arack",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/9075.jpg?s=c24a4869af2b93e464cfd613734879f7",
+            "language": "Italian",
+            "malId": 10572,
+            "name": "Sandri, Luca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69913.jpg?s=03f448f2af4a6bb42a34ecfaac57916f",
+            "language": "Spanish",
+            "malId": 59214,
+            "name": "Conde, Jesse"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71357.jpg?s=5b145425b3bfb8d5f24acc659c152f25",
+            "language": "Japanese",
+            "malId": 12705,
+            "name": "Murata, Taishi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/23483.jpg?s=eecbf2a96b038ab80d234e3e828fa418",
+            "language": "English",
+            "malId": 5361,
+            "name": "Pitts, Orion"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42495.jpg?s=464cb888a485224e64301f5965e95f14",
+            "language": "Portuguese (BR)",
+            "malId": 40374,
+            "name": "Vaccari, Hélio"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/357677.jpg?s=647964c5d0354db4d4f2eabf990bb9a9",
+        "malId": 161792,
+        "name": "Nigrisshi",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/54308.jpg?s=e0a97c1491150efff5e68005cd41dc12",
+            "language": "English",
+            "malId": 48698,
+            "name": "Allen, Jon"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65720.jpg?s=4295ec2c25f697f9717caad22a299818",
+            "language": "French",
+            "malId": 55541,
+            "name": "Melennec, Patrice"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58135.jpg?s=f0d78d8dd28abf06272c9d95dc16a21c",
+            "language": "Japanese",
+            "malId": 440,
+            "name": "Kishio, Daisuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76584.jpg?s=6743a777fff90f9535442f984555fb09",
+            "language": "Portuguese (BR)",
+            "malId": 43647,
+            "name": "Abreu, Marco Antônio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76691.jpg?s=7f55a410ed3d3dc964eb6f61295d4a12",
+            "language": "Spanish",
+            "malId": 67731,
+            "name": "Armijo Ugalde, Raymundo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/357682.jpg?s=2c94b2dcc41ec75508c34c1ab4954f58",
+        "malId": 161791,
+        "name": "Panchia",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58792.jpg?s=9da80c779e3d62436c37efb7dfa78735",
+            "language": "Japanese",
+            "malId": 299,
+            "name": "Nomura, Kenji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71654.jpg?s=94e8334e9be86a8212eb6f9a4646e562",
+            "language": "Spanish",
+            "malId": 61306,
+            "name": "Cárdenas, Hiram"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/358958.jpg?s=0667c413e8416d370a69557177974a49",
+        "malId": 151305,
+        "name": "Toppo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/36351.jpg?s=a04a04d3c3f2c9e39f5df688e5e6015b",
+            "language": "English",
+            "malId": 35077,
+            "name": "Hurd, Ray"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/70401.jpg?s=2414157f5bb31259424bb6c854bb6559",
+            "language": "Spanish",
+            "malId": 59793,
+            "name": "Alberto, Santos"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58792.jpg?s=9da80c779e3d62436c37efb7dfa78735",
+            "language": "Japanese",
+            "malId": 299,
+            "name": "Nomura, Kenji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1747.jpg?s=64086c109fcb5816620332de929f131e",
+            "language": "Italian",
+            "malId": 5033,
+            "name": "Ubaldi, Pietro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/66403.jpg?s=0c8cfa54bafdf0ac99fc1baa9eaff473",
+            "language": "French",
+            "malId": 56071,
+            "name": "Luccioni, José"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67282.jpg?s=f59b5a3404f5565c5087a6f61d8b0ea4",
+            "language": "Portuguese (BR)",
+            "malId": 37669,
+            "name": "Ramos, Mauro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/84905.jpg?s=941c45f92accd5663ebef3fade8060c3",
+            "language": "Hebrew",
+            "malId": 84683,
+            "name": "Vaknin, Raz"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/361039.jpg?s=8c8e0fea35a0f4cb441426b9d128f571",
+        "malId": 163385,
+        "name": "Roh",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/17323.jpg?s=31e73a6fc1a9e86dd9b460880c70fb9a",
+            "language": "Japanese",
+            "malId": 6241,
+            "name": "Masutani, Yasunori"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/75322.jpg?s=bbd134ebfe980767ba8f21a139e5e55f",
+            "language": "Portuguese (BR)",
+            "malId": 44016,
+            "name": "Luiz, Ítalo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70973.jpg?s=1aba7cd2df43c09aa01d9b74759c6e99",
+            "language": "Spanish",
+            "malId": 59418,
+            "name": "Ornelas, Jorge"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1263.jpg?s=fe422e26f09683bf7b55e4611d5f242d",
+            "language": "Italian",
+            "malId": 1267,
+            "name": "Rosa, Luigi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42855.jpg?s=3165af64d492c2000d5e16c366c4034d",
+            "language": "English",
+            "malId": 40701,
+            "name": "Snow, Derick"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67794.jpg?s=4889f2a9d67fbbe7f350ebbad644e909",
+            "language": "French",
+            "malId": 18873,
+            "name": "Bozo, Philippe"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/371639.jpg?s=cf06dfc35af8089b78e0148b97e18fee",
+        "malId": 6134,
+        "name": "Ginyu",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37131.jpg?s=c23880d991ef893051b99c68153594b6",
+            "language": "Italian",
+            "malId": 9534,
+            "name": "Balzarotti, Marco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68846.jpg?s=061e467dcf9aba73d9f21e1f555c7738",
+            "language": "Spanish",
+            "malId": 57482,
+            "name": "Soto, César"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69727.jpg?s=509403a4f0d0a9fe2e95fb52b95d082e",
+            "language": "Japanese",
+            "malId": 20,
+            "name": "Konishi, Katsuyuki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69790.jpg?s=590f8695b97c595bfb32380b6156fbcc",
+            "language": "French",
+            "malId": 56660,
+            "name": "Marais, Stéphane"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77173.jpg?s=b2cbd78bbaa33c44fc94abe68e2c1822",
+            "language": "Korean",
+            "malId": 68469,
+            "name": "Shim, Gyu-hyeok"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77477.jpg?s=3d23ccef3d344331658cb1474fbfeb09",
+            "language": "Portuguese (BR)",
+            "malId": 43704,
+            "name": "Azevedo, Fábio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/23393.jpg?s=bb80548212ab0bbf4009dc989fa90544",
+            "language": "English",
+            "malId": 480,
+            "name": "Elliott, R. Bruce"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/2751.jpg?s=d017fc51e3286e3abab2db93c087006e",
+            "language": "German",
+            "malId": 1669,
+            "name": "Räuker, Erich"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/52187.jpg?s=a6c855c7791bab6389925214579e636e",
+            "language": "Spanish",
+            "malId": 52910,
+            "name": "Tomé, Jorge"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76584.jpg?s=6743a777fff90f9535442f984555fb09",
+            "language": "Portuguese (BR)",
+            "malId": 43647,
+            "name": "Abreu, Marco Antônio"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/380629.jpg?s=adbe29058ca43b3ba381a555169c371f",
+        "malId": 155563,
+        "name": "Dyspo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/22858.jpg?s=77d5d57de7f575634fb515e69e76c4e5",
+            "language": "Japanese",
+            "malId": 20238,
+            "name": "Bonino, Giorgio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/60903.jpg?s=216667ada6db4bd9161e7fc4b32b7e59",
+            "language": "Portuguese (BR)",
+            "malId": 21343,
+            "name": "Guedes, Douglas"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71487.jpg?s=ef04f02f771bd3e70346ec1de2fae53c",
+            "language": "Spanish",
+            "malId": 57329,
+            "name": "Hernández, Carlos"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/87556.jpg?s=ef3a42b86931776c5311dfd05f2b9f26",
+            "language": "Japanese",
+            "malId": 651,
+            "name": "Shimada, Bin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58260.jpg?s=2bb75a848d36eda0b74c32b66e042e1a",
+            "language": "English",
+            "malId": 50528,
+            "name": "Piper, Christopher Dontrell"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/39620.jpg?s=4659da52ac594a3593f29400b7c46a6f",
+        "malId": 18064,
+        "name": "Norimaki, Turbo",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/71204.jpg?s=dd6923f1951d32ba43880275c519a412",
+        "malId": 2108,
+        "name": "Oolong",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/11144.jpg?s=ec5cca2a1708e783a81da653cbea84e3",
+            "language": "German",
+            "malId": 11905,
+            "name": "Völger, Bernhard"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/19383.jpg?s=486441b0fb0107e0330a061b42c4a82a",
+            "language": "Hungarian",
+            "malId": 7827,
+            "name": "Csongor, Szalay"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/25229.jpg?s=8c759628b433a435505cad16e3e9a242",
+            "language": "Italian",
+            "malId": 21933,
+            "name": "Peroni, Riccardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/22996.jpg?s=e8e506a8ba3e64ade123bca509261d86",
+            "language": "English",
+            "malId": 1356,
+            "name": "Jackson, Brad"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33099.jpg?s=593765acb092dfc83f74aec2bdf4cef6",
+            "language": "Japanese",
+            "malId": 1522,
+            "name": "Tatsuta, Naoki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/44411.jpg?s=3d2a27b5b55f6aeb2688dd3cab1cf581",
+            "language": "French",
+            "malId": 39332,
+            "name": "Ariotti, Philippe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47194.jpg?s=fa0f6dee515ac01718c8197c32a8ef3d",
+            "language": "English",
+            "malId": 39799,
+            "name": "Chase, Ray"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63858.jpg?s=a181b9b647ecceadd7eb092f2b11a75b",
+            "language": "Portuguese (BR)",
+            "malId": 11637,
+            "name": "Santos, Angélica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/24639.jpg?s=a5602f2f8b05a85abd8793ee1a41e71b",
+            "language": "Spanish",
+            "malId": 21469,
+            "name": "Lezama, Ernesto"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/71739.jpg?s=f9177c6e82901595feda40788c840c66",
+        "malId": 2141,
+        "name": "Pilaf",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/25497.jpg?s=1def449b3096a61dd931ac85812a7f8a",
+            "language": "English",
+            "malId": 250,
+            "name": "Huber, Chuck"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/45994.jpg?s=a0549b86e15076bbdb15f095d1298572",
+            "language": "Italian",
+            "malId": 42633,
+            "name": "Lotti, Massimiliano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/87607.jpg?s=2cc6f3b156bc1103e1dab3dc12eaa92e",
+            "language": "Japanese",
+            "malId": 255,
+            "name": "Chiba, Shigeru"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/14225.jpg?s=aecce1147f536f958e4e326647902924",
+            "language": "Hungarian",
+            "malId": 13985,
+            "name": "Harsányi, Gábor"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/39687.jpg?s=a65a8ef31eabce51b41e7d043904398e",
+            "language": "English",
+            "malId": 771,
+            "name": "Fahn, Tom"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/33221.jpg?s=4bc800c5e6765d7069da78a3bcbc3263",
+            "language": "German",
+            "malId": 7219,
+            "name": "Bösherz, Konrad"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/65908.jpg?s=919fb0784b3a9f8b52171293bdee250a",
+            "language": "Spanish",
+            "malId": 10028,
+            "name": "Atala, Yamil"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71252.jpg?s=7a8455456d186cf2cce7119bd3d7c414",
+            "language": "French",
+            "malId": 9882,
+            "name": "Pascal, Benjamin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76031.jpg?s=c66e42840900e26ac315280abca952eb",
+            "language": "Portuguese (BR)",
+            "malId": 8882,
+            "name": "Sodre, Elcio"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/15/72546.jpg?s=c434a442d8ad1212885a8d02dbcbbee0",
+        "malId": 246,
+        "name": "Son, Gokuu",
+        "role": "Main",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/28305.jpg?s=02832679e4cc67f6ea16e57a428dcb21",
+            "language": "English",
+            "malId": 180,
+            "name": "Lang, Lex"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30191.jpg?s=ae2728aa271ed956b5a0b72e7a047cbc",
+            "language": "English",
+            "malId": 472,
+            "name": "Clinkenbeard, Colleen"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/42833.jpg?s=4333bd5e0eeb42a25b312aec15072e4c",
+            "language": "English",
+            "malId": 1000,
+            "name": "Schemmel, Sean"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/50634.jpg?s=62712c71d5bc89040e867e1066a5caf8",
+            "language": "Spanish",
+            "malId": 46859,
+            "name": "Domínguez, Pablo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67475.jpg?s=ad2f54851db7574a6ee173648bb18eb4",
+            "language": "French",
+            "malId": 39328,
+            "name": "Borg, Patrick"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68448.jpg?s=dda9297ac611a4bb2c1723b60655d11a",
+            "language": "Hebrew",
+            "malId": 63161,
+            "name": "Meir Vanunu, Avraham"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46741.jpg?s=3b9f0663cd9c6a33fab6b1d8eb77235a",
+            "language": "Portuguese (BR)",
+            "malId": 43077,
+            "name": "Feist, Henrique"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77340.jpg?s=2e78abe7d4d8d4fe06bc2e8bfb87fc0e",
+            "language": "Japanese",
+            "malId": 557,
+            "name": "Nozawa, Masako"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/27459.jpg?s=75949c01cc9ff34aef85f23a271bbab5",
+            "language": "Spanish",
+            "malId": 5682,
+            "name": "Torres, Laura"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/3397.jpg?s=71b6163ba268592e939307c4e235beee",
+            "language": "Korean",
+            "malId": 6499,
+            "name": "Kim, Yeong Seon"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/37157.jpg?s=37ac121dd5f6b4265263f43015e3be40",
+            "language": "Italian",
+            "malId": 1289,
+            "name": "Moneta, Claudio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/40070.jpg?s=dbbede0acf7082d5c715bbd8703c2ca0",
+            "language": "English",
+            "malId": 406,
+            "name": "Sampler, Philece"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/41158.jpg?s=a6dbd4d3b308022259f1df9eeac42e90",
+            "language": "German",
+            "malId": 40200,
+            "name": "Bräuler, Stefan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/5053.jpg?s=7e72bfb86fc29b38368d2a14e43afc17",
+            "language": "Hungarian",
+            "malId": 7798,
+            "name": "Lippai, László"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/61222.jpg?s=56480c6e6283f5833eac72fa85e280f9",
+            "language": "Portuguese (BR)",
+            "malId": 8241,
+            "name": "Bezerra, Úrsula"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/69406.jpg?s=7fde89d7af43679e48098a912c4ee467",
+            "language": "Spanish",
+            "malId": 1461,
+            "name": "Castañeda, Mario"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/75915.jpg?s=316e3918010e01a30c5754942cde27b9",
+            "language": "Portuguese (BR)",
+            "malId": 1830,
+            "name": "Bezerra, Wendel"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/111834.jpg?s=ea56abfe1d0227736eb124a12f2b0c03",
+        "malId": 9775,
+        "name": "Kibito",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/25497.jpg?s=1def449b3096a61dd931ac85812a7f8a",
+            "language": "English",
+            "malId": 250,
+            "name": "Huber, Chuck"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/44811.jpg?s=43dba024168ab6ed70c405395250bf98",
+            "language": "Japanese",
+            "malId": 9016,
+            "name": "Aomori, Shin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46574.jpg?s=f050a031330681f992c90a359315152d",
+            "language": "Italian",
+            "malId": 42884,
+            "name": "Gaude, Gianni"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67278.jpg?s=c832d79a38e6cb9f1e631bb7e69006e4",
+            "language": "Portuguese (BR)",
+            "malId": 43719,
+            "name": "Moreno, Antônio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67569.jpg?s=6e8c58a7e3484cc1a1cf3ef57f7f93f9",
+            "language": "Spanish",
+            "malId": 56689,
+            "name": "Solórzano, Humberto"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/144265.jpg?s=f6366a9bc626f68ced3a7e80822b84b7",
+        "malId": 18072,
+        "name": "Soramame, Peasuke",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/240055.jpg?s=7ac6839d88c70efbe9849b8e340869e1",
+        "malId": 103469,
+        "name": "Piiza",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/29089.jpg?s=f95b4d1ea824683692115e6f8aea6266",
+            "language": "English",
+            "malId": 252,
+            "name": "Young, Linda"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/38732.jpg?s=2377e116f9ab532c9c60d74ddbd77bde",
+            "language": "German",
+            "malId": 25475,
+            "name": "Haseney, Tina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/57137.jpg?s=dcd648a00d69c253148e82e9eac56052",
+            "language": "Japanese",
+            "malId": 27495,
+            "name": "Morishita, Yukiko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/62929.jpg?s=13fe8dfb4c427cf172a20b0afb767a48",
+            "language": "Portuguese (BR)",
+            "malId": 46047,
+            "name": "Matta, Bruna"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67476.jpg?s=ff50105bede34513c44198b231e6e6b1",
+            "language": "French",
+            "malId": 1613,
+            "name": "Lecordier, Brigitte"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73374.jpg?s=608c761c303f1aa67603d19c515a93a8",
+            "language": "Spanish",
+            "malId": 11424,
+            "name": "Guerrero, Dulce"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/298390.jpg?s=fe93624e3e0c42f361e9be732c5b2d82",
+        "malId": 137557,
+        "name": "Magetta",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33099.jpg?s=593765acb092dfc83f74aec2bdf4cef6",
+            "language": "Japanese",
+            "malId": 1522,
+            "name": "Tatsuta, Naoki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77037.jpg?s=935f8d65a1d28ec8b414b3521c042f16",
+            "language": "Spanish",
+            "malId": 68275,
+            "name": "Trejo Rodríguez, Osvaldo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/86793.jpg?s=dc4d995944a059ab1757184c40ac4e59",
+            "language": "Italian",
+            "malId": 25405,
+            "name": "Oldani, Andrea"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68355.jpg?s=e26149a136416971b2700fc83fa157a0",
+            "language": "Portuguese (BR)",
+            "malId": 43692,
+            "name": "Garcia, Roberto"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/299020.jpg?s=d8ca7d24aadc37e95b7ec5c9d96d3e15",
+        "malId": 89551,
+        "name": "Tights",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/24249.jpg?s=683c99ba6b0f35b36a08c906516394dd",
+            "language": "Japanese",
+            "malId": 354,
+            "name": "Tsuru, Hiromi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/4628.jpg?s=a8067c2be132c281cc947fb9e75336b2",
+            "language": "Italian",
+            "malId": 7533,
+            "name": "Bielli, Francesca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/23831.jpg?s=4f06fcffad8e0741464361db9e99e8ca",
+            "language": "English",
+            "malId": 10292,
+            "name": "Munoz, Anastasia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/62737.jpg?s=a3ad5eba313bd6b168aabb24d3923105",
+            "language": "Portuguese (BR)",
+            "malId": 43628,
+            "name": "Ferreira, Priscila"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67476.jpg?s=ff50105bede34513c44198b231e6e6b1",
+            "language": "French",
+            "malId": 1613,
+            "name": "Lecordier, Brigitte"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71212.jpg?s=593d46abacc1eaabaa0f9bc76750571b",
+            "language": "Spanish",
+            "malId": 62376,
+            "name": "Manjarrez, Mónica"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/313192.jpg?s=88072944413a3bc1db733cb7fe3cadea",
+        "malId": 142182,
+        "name": "Potage",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/1137.jpg?s=8e6074d391f0dcc03a827730c0a241ef",
+            "language": "Italian",
+            "malId": 1093,
+            "name": "Paiola, Antonio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58724.jpg?s=0241898f6a96b6ba7de676a4dbcc1de8",
+            "language": "Japanese",
+            "malId": 1431,
+            "name": "Saitou, Shirou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/66403.jpg?s=0c8cfa54bafdf0ac99fc1baa9eaff473",
+            "language": "French",
+            "malId": 56071,
+            "name": "Luccioni, José"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67282.jpg?s=f59b5a3404f5565c5087a6f61d8b0ea4",
+            "language": "Portuguese (BR)",
+            "malId": 37669,
+            "name": "Ramos, Mauro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73329.jpg?s=2f5b1f1c52ad826f799f4976ca1da0e3",
+            "language": "Spanish",
+            "malId": 59823,
+            "name": "López, Herman"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/357636.jpg?s=efaf6533e52d066e0b44b9e0dc3350a1",
+        "malId": 161803,
+        "name": "Saonel",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/23000.jpg?s=623ddc9be01ec6d9a0c2865a1f638c2f",
+            "language": "English",
+            "malId": 611,
+            "name": "Potter, Brandon"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/17561.jpg?s=a5ff9119dcead05d778a479c266347f4",
+            "language": "Japanese",
+            "malId": 96,
+            "name": "Canna, Nobutoshi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/74609.jpg?s=b448231b233f2c94ecaf2b1fb14d28c8",
+            "language": "Portuguese (BR)",
+            "malId": 44522,
+            "name": "Teles​, Ricardo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/357646.jpg?s=53a7c9d63f61dd62f8817d724a0a02df",
+        "malId": 161801,
+        "name": "Gamisaras",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/87556.jpg?s=ef3a42b86931776c5311dfd05f2b9f26",
+            "language": "Japanese",
+            "malId": 651,
+            "name": "Shimada, Bin"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/357685.jpg?s=eeee4eb6e7c4374f7039a642c4a574d6",
+        "malId": 161775,
+        "name": "Rabanra",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/64738.jpg?s=da0022ee2650a900c5aa32ec81cebdb3",
+            "language": "Portuguese (BR)",
+            "malId": 11869,
+            "name": "Soares, Renato"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65561.jpg?s=f06a9cd2984bebc086b7fe35770daa3d",
+            "language": "Japanese",
+            "malId": 205,
+            "name": "Morita, Masakazu"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/357700.jpg?s=ed06621e2d1af4f60bbf18861f4ec9b3",
+        "malId": 161774,
+        "name": "Zarbuto",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46574.jpg?s=f050a031330681f992c90a359315152d",
+            "language": "Italian",
+            "malId": 42884,
+            "name": "Gaude, Gianni"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/61731.jpg?s=477daf60d639132ea24a299c9d0ffc7a",
+            "language": "Portuguese (BR)",
+            "malId": 46395,
+            "name": "Guerra, José Carlos"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68421.jpg?s=93aeac7c3dec38a17f7fe4f2f58a0faf",
+            "language": "Spanish",
+            "malId": 57312,
+            "name": "Rangel, Óscar"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/40450.jpg?s=4b23fe47027b3434eeae29c5f0b16c94",
+            "language": "Japanese",
+            "malId": 7713,
+            "name": "Kawazu, Yasuhiko"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/357827.jpg?s=b534f1305647f468ace8d2ab740da63d",
+        "malId": 2103,
+        "name": "Dr. Briefs",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/84639.jpg?s=04305c76d8aff35b71219346e81f5587",
+            "language": "Portuguese (BR)",
+            "malId": 43822,
+            "name": "Cruz, Walter"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/18159.jpg?s=3d7951b5c204e9befd0987e104267682",
+            "language": "Japanese",
+            "malId": 1675,
+            "name": "Tanaka, Ryouichi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/12479.jpg?s=8d528239928fc78578d8920a0552dc9b",
+            "language": "English",
+            "malId": 474,
+            "name": "Stoddard, Mark"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/33225.jpg?s=71bad9db4becc1b5c0561950f0f9b739",
+            "language": "German",
+            "malId": 1219,
+            "name": "Staudinger, Stefan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71219.jpg?s=493b5311ee8e001edc32fe35a5e3a220",
+            "language": "Spanish",
+            "malId": 60985,
+            "name": "Hill, Ricardo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/358470.jpg?s=847608d66b93701411c20bbd444ea68f",
+        "malId": 162260,
+        "name": "Copy Vegeta",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30181.jpg?s=d5dd30d9e92386e9f8d26770b8ccb838",
+            "language": "French",
+            "malId": 1150,
+            "name": "Legrand, Eric"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37125.jpg?s=3a1e02f697e98262309bca2797d0575e",
+            "language": "Italian",
+            "malId": 1087,
+            "name": "Iacono, Gianluca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65561.jpg?s=f06a9cd2984bebc086b7fe35770daa3d",
+            "language": "Japanese",
+            "malId": 205,
+            "name": "Morita, Masakazu"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69407.jpg?s=51707e9cb717cf2dbd46b261f5ab5f0c",
+            "language": "Spanish",
+            "malId": 1698,
+            "name": "García, René"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/39588.jpg?s=a759ac009ffbae849a262f186ff8fb2f",
+            "language": "English",
+            "malId": 515,
+            "name": "Drummond, Brian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/5026.jpg?s=4f59f87ae59696867902174412477773",
+            "language": "Hungarian",
+            "malId": 7769,
+            "name": "Czető, Roland"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79734.jpg?s=9de7362478bc71a1eadbf32f7d249737",
+            "language": "Portuguese (BR)",
+            "malId": 7350,
+            "name": "Rollo, Alfredo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/358946.jpg?s=efe79d5ceb831008afd7d0a61faac0d5",
+        "malId": 154010,
+        "name": "Basil",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "Italian",
+            "malId": 43063,
+            "name": "Trombini, Maurizio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46079.jpg?s=b28e98fba68f4fe2091920c3fb4df6c1",
+            "language": "Japanese",
+            "malId": 285,
+            "name": "Koyama, Tsuyoshi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/76571.jpg?s=542d15fba60e724322a7748ac60c6c73",
+            "language": "Portuguese (BR)",
+            "malId": 52956,
+            "name": "Barone, Alex"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68421.jpg?s=93aeac7c3dec38a17f7fe4f2f58a0faf",
+            "language": "Spanish",
+            "malId": 57312,
+            "name": "Rangel, Óscar"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/59397.jpg?s=be09145e42d919db725e86a154cb2f07",
+            "language": "English",
+            "malId": 22625,
+            "name": "Plunk, Jeff"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71252.jpg?s=7a8455456d186cf2cce7119bd3d7c414",
+            "language": "French",
+            "malId": 9882,
+            "name": "Pascal, Benjamin"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/359111.jpg?s=5f853ae50101da5be3905c4559408784",
+        "malId": 161810,
+        "name": "Chappil",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/86309.jpg?s=5a323b8665bd862d208ef90f24cf9587",
+            "language": "Spanish",
+            "malId": 16673,
+            "name": "Campuzano, Manuel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/64429.jpg?s=1b6a5d70c845485ca1a1e080be242f00",
+            "language": "English",
+            "malId": 63078,
+            "name": "Harris, Taylor"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66152.jpg?s=78aec440f9f1c805a76ce9b56fdea526",
+            "language": "Portuguese (BR)",
+            "malId": 52883,
+            "name": "Mazzei, Wilken"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/88034.jpg?s=82dad37fd844ac0473d58f1e283e2cd1",
+            "language": "Japanese",
+            "malId": 1832,
+            "name": "Takatsuka, Masaya"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82886.jpg?s=1cb1e1ad07b766491ca9f587674a4b0b",
+            "language": "French",
+            "malId": 55488,
+            "name": "Rehlinger, Boris"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/359112.jpg?s=68db4dd1cf76f0179d2a860f946514ee",
+        "malId": 161809,
+        "name": "Hyssop",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/24105.jpg?s=08936fd59a8f22078535ea1a200b6005",
+            "language": "English",
+            "malId": 9777,
+            "name": "Wald, David"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/75610.jpg?s=10ca4c1815f4e4f73145d7504b01c0a2",
+            "language": "Portuguese (BR)",
+            "malId": 5139,
+            "name": "Sawaya, Ricardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73596.jpg?s=36ce828518bac787c697b2b471645fac",
+            "language": "Japanese",
+            "malId": 134,
+            "name": "Kusao, Takeshi"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/16/48582.jpg?s=79dd6757c70b3dc78cc4e1739affe6d4",
+        "malId": 2147,
+        "name": "Jinzouningen 17-gou",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/14595.jpg?s=6b3031919660058e373698f3565b6f71",
+            "language": "German",
+            "malId": 7378,
+            "name": "Stollberg, Dirk"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/22702.jpg?s=f8a4d9f036f35f61ab51dd8c9f440e37",
+            "language": "Italian",
+            "malId": 1268,
+            "name": "Prata, Patrizio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/25497.jpg?s=1def449b3096a61dd931ac85812a7f8a",
+            "language": "English",
+            "malId": 250,
+            "name": "Huber, Chuck"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65093.jpg?s=8096a0ac5eea3d67648fec068111e332",
+            "language": "French",
+            "malId": 1201,
+            "name": "Bourdon, Thierry"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/82441.jpg?s=84dd5d493fca65f5fc824aa18e849f2c",
+            "language": "Spanish",
+            "malId": 79041,
+            "name": "Flores, David"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/52114.jpg?s=0d389125456ee7c24ae035b26bc1c002",
+            "language": "Japanese",
+            "malId": 445,
+            "name": "Nakahara, Shigeru"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68394.jpg?s=021cbe07de790fe979d796677453cb41",
+            "language": "Spanish",
+            "malId": 57250,
+            "name": "Vásquez, Genaro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/69910.jpg?s=57730a912dd095b8699d5b178f5cc687",
+            "language": "Portuguese (BR)",
+            "malId": 43699,
+            "name": "Júnior, Figueira"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/144267.jpg?s=7f7cb044fff34cbb976fe12727dcd20d",
+        "malId": 18065,
+        "name": "Yamabuki, Midori",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/298388.jpg?s=7cc4456b2484c7c2d8a48afd11aa98b1",
+        "malId": 137555,
+        "name": "Frost",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/42527.jpg?s=25648795af594071cb0a9872d9851932",
+            "language": "Spanish",
+            "malId": 40377,
+            "name": "Corpa, Ángel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65678.jpg?s=492c982f157200ceb1c87c3e7d5c72d3",
+            "language": "Japanese",
+            "malId": 259,
+            "name": "Nakao, Ryusei"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/40745.jpg?s=591ba292d84ec5e9d7d1b5596f3a6668",
+            "language": "Portuguese (BR)",
+            "malId": 14487,
+            "name": "Campanile, Carlos"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/44411.jpg?s=3d2a27b5b55f6aeb2688dd3cab1cf581",
+            "language": "French",
+            "malId": 39332,
+            "name": "Ariotti, Philippe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/65118.jpg?s=1276e1d4e14a671d299dafac28b91ede",
+            "language": "Italian",
+            "malId": 1283,
+            "name": "Zanandrea, Federico"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/75912.jpg?s=f436f8ac7763d8c42b2257bc39113b42",
+            "language": "Spanish",
+            "malId": 10024,
+            "name": "Reyero, Gerardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/12455.jpg?s=a34115be18946ae76075034079a167b7",
+            "language": "English",
+            "malId": 192,
+            "name": "Ayres, Greg"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/302747.jpg?s=876ee35137eed20f5f7fbe19e824c95a",
+        "malId": 138973,
+        "name": "Gingaou",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/73324.jpg?s=95b7adfc7da39c49961ddf117a4a5a65",
+            "language": "Spanish",
+            "malId": 57419,
+            "name": "Lacy, Daniel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/73508.jpg?s=ba9d9e3e3156c4edbc6cbccde307468e",
+            "language": "Japanese",
+            "malId": 231,
+            "name": "Uo, Ken"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/78102.jpg?s=ef2bbdfd265e16a813ec4bb5781494e5",
+            "language": "Portuguese (BR)",
+            "malId": 43859,
+            "name": "Morales, Alex"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/46563.jpg?s=47bdbb1f0c9a58b999e75b0a99d2a529",
+            "language": "Italian",
+            "malId": 43064,
+            "name": "Rasini, Cesare"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/325434.jpg?s=6b001290d97b8f50c163036e239034bd",
+        "malId": 149346,
+        "name": "Helles",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/32687.jpg?s=d9e617b645dbafdbee1c2f3c66d46140",
+            "language": "French",
+            "malId": 31621,
+            "name": "Ropion, Joséphine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46572.jpg?s=761635c867c77656ca499c7e94cad828",
+            "language": "Italian",
+            "malId": 42887,
+            "name": "Thovez, Marina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/57708.jpg?s=14507772a7d4efb4741e0fbd7eedfafd",
+            "language": "Japanese",
+            "malId": 77,
+            "name": "Asano, Masumi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/60261.jpg?s=f030ecc72a46a450a250595103509e40",
+            "language": "Portuguese (BR)",
+            "malId": 43862,
+            "name": "Cardoso, Maria Cláudia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/22015.jpg?s=aa5ab5b683e3aa4bb00305d20c270488",
+            "language": "Spanish",
+            "malId": 1846,
+            "name": "Hernández, Cristina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82439.jpg?s=8530a3482a67a49979986deb7be72e25",
+            "language": "Spanish",
+            "malId": 78982,
+            "name": "Paredes, Numa"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/357654.jpg?s=7e18d857c94ff1f1a54374f02d1cec47",
+        "malId": 161817,
+        "name": "Jirasen",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/82211.jpg?s=053b4e968b0be9e90fa60f1d93a07db9",
+            "language": "Spanish",
+            "malId": 78426,
+            "name": "Moreno, Pablo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69876.jpg?s=f184a4147aee4e1d681f62783e8a84bf",
+            "language": "Portuguese (BR)",
+            "malId": 44292,
+            "name": "Emílio, César"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/88034.jpg?s=82dad37fd844ac0473d58f1e283e2cd1",
+            "language": "Japanese",
+            "malId": 1832,
+            "name": "Takatsuka, Masaya"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/357828.jpg?s=f07a58b451c4312cece1db2aa84ebdf8",
+        "malId": 4318,
+        "name": "Jinzouningen 18-gou",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/12148.jpg?s=9b8674f8504b40b83cfcd8257cde63ce",
+            "language": "German",
+            "malId": 1210,
+            "name": "Borgwardt, Diana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/22077.jpg?s=48ec0743527614315e4688fa541305a0",
+            "language": "Spanish",
+            "malId": 20138,
+            "name": "Villasenor, Monica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/15553.jpg?s=19a8906c1ca33350a521145688fda972",
+            "language": "Italian",
+            "malId": 1088,
+            "name": "Magnaghi, Debora"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/23499.jpg?s=05baf51299ed77d162d1fce7a881a415",
+            "language": "English",
+            "malId": 535,
+            "name": "McCoy, Meredith"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/58342.jpg?s=563c701e2f50a334961c4549ecf98415",
+            "language": "Japanese",
+            "malId": 121,
+            "name": "Itou, Miki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/65119.jpg?s=3fa4bb4ab3c71f68a0c5faed77a9e8a7",
+            "language": "English",
+            "malId": 44506,
+            "name": "Ryan, Tamara"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67476.jpg?s=ff50105bede34513c44198b231e6e6b1",
+            "language": "French",
+            "malId": 1613,
+            "name": "Lecordier, Brigitte"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85396.jpg?s=d0d25908ef7dc48912562d7236214016",
+            "language": "Portuguese (BR)",
+            "malId": 26521,
+            "name": "Prado, Eleonora"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/358931.jpg?s=0daf7d854001f4db7dabe6c4194659d7",
+        "malId": 2110,
+        "name": "Uranai Baba",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/29089.jpg?s=f95b4d1ea824683692115e6f8aea6266",
+            "language": "English",
+            "malId": 252,
+            "name": "Young, Linda"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/44905.jpg?s=9951235d6babb6c1c1ac9e6d4998316d",
+            "language": "French",
+            "malId": 24241,
+            "name": "Fauveau, Jennifer"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/42347.jpg?s=706bcef9b3ca45f3e35e7926ef008716",
+            "language": "Portuguese (BR)",
+            "malId": 40350,
+            "name": "Zordan, Zaíra"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71210.jpg?s=83fdf7999c95b49faccdd908a425906f",
+            "language": "Spanish",
+            "malId": 61064,
+            "name": "Villanueva Vargas, Ángela"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73373.jpg?s=5f12d8c1574269f19104f2dfc9188ef2",
+            "language": "Japanese",
+            "malId": 75,
+            "name": "Tanaka, Mayumi"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/359095.jpg?s=20a23e6a36f9042b2258e6b40c97c829",
+        "malId": 161784,
+        "name": "Narirama",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48658.jpg?s=7d876fc697a870a2470684c5416f0f31",
+            "language": "English",
+            "malId": 36888,
+            "name": "Mills, Daman"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67494.jpg?s=45a31cbddbeef723c8a3ce90d6041465",
+            "language": "French",
+            "malId": 56644,
+            "name": "Atlan, Jean-Luc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69876.jpg?s=f184a4147aee4e1d681f62783e8a84bf",
+            "language": "Portuguese (BR)",
+            "malId": 44292,
+            "name": "Emílio, César"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/81680.jpg?s=4ed4cee47408e765901cb9d67c6ee3e3",
+            "language": "Spanish",
+            "malId": 77491,
+            "name": "Rocha, Ricardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/66263.jpg?s=b1e93177572a242a439cdab5bb90b3f4",
+            "language": "German",
+            "malId": 52995,
+            "name": "Aldag, Immanuel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73596.jpg?s=36ce828518bac787c697b2b471645fac",
+            "language": "Japanese",
+            "malId": 134,
+            "name": "Kusao, Takeshi"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/359113.jpg?s=4ab2f7ba4f9bb980462b49f20dfbe444",
+        "malId": 161808,
+        "name": "Oregano",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/17323.jpg?s=31e73a6fc1a9e86dd9b460880c70fb9a",
+            "language": "Japanese",
+            "malId": 6241,
+            "name": "Masutani, Yasunori"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48193.jpg?s=9ee5eccfe393ed34cefc0b683040677b",
+            "language": "English",
+            "malId": 22629,
+            "name": "Wehkamp, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65720.jpg?s=4295ec2c25f697f9717caad22a299818",
+            "language": "French",
+            "malId": 55541,
+            "name": "Melennec, Patrice"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71392.jpg?s=cd257aa17be7d403c69266bb6045d127",
+            "language": "Portuguese (BR)",
+            "malId": 43709,
+            "name": "Marques, Guilherme"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/364675.jpg?s=ea5aa87ec4ee9476ea2b29ab2aa7c019",
+        "malId": 163379,
+        "name": "Ea",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80528.jpg?s=f82a08a67443a0009ebf561ab119047f",
+            "language": "Italian",
+            "malId": 46634,
+            "name": "Sansalone, Dario"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47113.jpg?s=feae1bb33be3f2958c0f6a487dfcccff",
+            "language": "Portuguese (BR)",
+            "malId": 43723,
+            "name": "Loy, João"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/55933.jpg?s=8f707ff59c72240a5df190acced75e41",
+            "language": "Japanese",
+            "malId": 6145,
+            "name": "Naruse, Makoto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/76012.jpg?s=eb1f21b17c1a22da800e296e0271d881",
+            "language": "English",
+            "malId": 66467,
+            "name": "Coy, Alfie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/66262.jpg?s=82e05826d3a24917eb2f430b1177902f",
+            "language": "German",
+            "malId": 21417,
+            "name": "Wolko, Roman"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/70815.jpg?s=ce673cdc02a4588aeb5a0ec3f8f913e7",
+            "language": "Spanish",
+            "malId": 57185,
+            "name": "Orozco, Luis Fernando"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/72010.jpg?s=5deb8bf4f428638ef57c2ac3e45277b3",
+            "language": "French",
+            "malId": 55020,
+            "name": "Borg, Yoann"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/77077.jpg?s=3f6b09de57095c4bdc79b99f9a8da2dd",
+            "language": "Portuguese (BR)",
+            "malId": 52954,
+            "name": "Novaes, Rodolfo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/48517.jpg?s=19014a6433cd36c32f3661b21b38dad3",
+        "malId": 2159,
+        "name": "Kuririn",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "Spanish",
+            "malId": 85642,
+            "name": "Neira, Ángeles"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37035.jpg?s=8d20cb1dce639c5ae917f39d7f3baf55",
+            "language": "English",
+            "malId": 1361,
+            "name": "Beacock, Brian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69304.jpg?s=297445949d65f68d5415ee57654224c7",
+            "language": "Portuguese (BR)",
+            "malId": 1108,
+            "name": "Lucindo, Fábio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/12539.jpg?s=1f86240be620ed5b429bcc8ff500c270",
+            "language": "English",
+            "malId": 360,
+            "name": "Strait, Sonny"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/26195.jpg?s=80b4447fa5588c43fef28453166174c2",
+            "language": "Italian",
+            "malId": 23535,
+            "name": "Scribani, Luigi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67512.jpg?s=031798e96f27170237be615b355a9c64",
+            "language": "French",
+            "malId": 56654,
+            "name": "Nevers, Monique"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1568.jpg?s=0abf531c41a6ba408f8607f6d8cd2c2f",
+            "language": "Italian",
+            "malId": 1663,
+            "name": "Silvestri, Marcella"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/23126.jpg?s=ac9be65a13ade3bd15f563b370444588",
+            "language": "Hungarian",
+            "malId": 20062,
+            "name": "Berkes, Bence"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/41156.jpg?s=a01e6bd8e5b6e1b160e66235705f33d6",
+            "language": "German",
+            "malId": 40198,
+            "name": "Gärtner, Daniel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68498.jpg?s=3de3b17beea5590b7f85969262cb0ed3",
+            "language": "Spanish",
+            "malId": 7094,
+            "name": "Garza, Eduardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73373.jpg?s=5f12d8c1574269f19104f2dfc9188ef2",
+            "language": "Japanese",
+            "malId": 75,
+            "name": "Tanaka, Mayumi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73826.jpg?s=b541090312dbd704a1e31a6f405c0bb8",
+            "language": "English",
+            "malId": 1351,
+            "name": "Steele, Laurie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/84905.jpg?s=941c45f92accd5663ebef3fade8060c3",
+            "language": "Hebrew",
+            "malId": 84683,
+            "name": "Vaknin, Raz"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/48724.jpg?s=ebed3c4d0d5b80d5549185caba758b34",
+        "malId": 9377,
+        "name": "Mr. Satan",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/23983.jpg?s=2134950774012a629fd5ffd98a1ca084",
+            "language": "English",
+            "malId": 1342,
+            "name": "Rager, Chris"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/38697.jpg?s=f65a8e851d1d61107407514b9df94e61",
+            "language": "English",
+            "malId": 353,
+            "name": "Price, Jamieson"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46528.jpg?s=9c4e11cb254a46a34db5641e697fb7a9",
+            "language": "Italian",
+            "malId": 43036,
+            "name": "Lombardo, Riccardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/17135.jpg?s=5925123b8a7cf9b51a445c225442f0ef",
+            "language": "Japanese",
+            "malId": 357,
+            "name": "Ishizuka, Unshou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/48405.jpg?s=1c556d061fe70aefe09129da42ea04a6",
+            "language": "German",
+            "malId": 45041,
+            "name": "Gutmann, Elmar"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/48841.jpg?s=795d640b909e090c8c88f6650acfb74f",
+            "language": "French",
+            "malId": 39333,
+            "name": "Bouraly, Frédéric"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/72267.jpg?s=6eb7c2895db8c7c42fef5998daca15b8",
+            "language": "Spanish",
+            "malId": 62223,
+            "name": "Miranda, Bardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/52187.jpg?s=a6c855c7791bab6389925214579e636e",
+            "language": "Spanish",
+            "malId": 52910,
+            "name": "Tomé, Jorge"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/69616.jpg?s=e7688e25a3acb86514c0b855f66d46a8",
+            "language": "Portuguese (BR)",
+            "malId": 11531,
+            "name": "Lopes, Guilherme"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/2/72715.jpg?s=886561eebbd32941685b470ff9ed78a2",
+        "malId": 2093,
+        "name": "Son, Gohan",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/1284.jpg?s=7341f1a2dc0fe5c0ad0d038563f0b469",
+            "language": "Italian",
+            "malId": 1160,
+            "name": "Garbolino, Davide"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/38702.jpg?s=4787dbfdcce1b482a18261660cb67956",
+            "language": "English",
+            "malId": 336,
+            "name": "Hebert, Kyle"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48096.jpg?s=51e3973ef2690d4b57bd33d9c62e8533",
+            "language": "Spanish",
+            "malId": 44722,
+            "name": "Mendoza, Luis Alfonso"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/79135.jpg?s=e589ea7c273066de6de437841eb2dff0",
+            "language": "English",
+            "malId": 37815,
+            "name": "Hackney, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46741.jpg?s=3b9f0663cd9c6a33fab6b1d8eb77235a",
+            "language": "Portuguese (BR)",
+            "malId": 43077,
+            "name": "Feist, Henrique"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/5589.jpg?s=9a5223e079cba04e9fd9c4c501850f5d",
+            "language": "Hungarian",
+            "malId": 8386,
+            "name": "Penke, Bence"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/75284.jpg?s=cdea5cdd1331587131c9f60554f65f87",
+            "language": "Portuguese (BR)",
+            "malId": 5138,
+            "name": "Fagundes, Vagner"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77340.jpg?s=2e78abe7d4d8d4fe06bc2e8bfb87fc0e",
+            "language": "Japanese",
+            "malId": 557,
+            "name": "Nozawa, Masako"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/85388.jpg?s=88c321f1eb8ca26bf78dd73604e52507",
+            "language": "Spanish",
+            "malId": 85641,
+            "name": "Albaiceta, Alejandro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/59384.jpg?s=95a5281fa832511db5c2c28d98f4515f",
+            "language": "German",
+            "malId": 11906,
+            "name": "Fitzner, Sebastian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67477.jpg?s=f384463922bbc87d964785549bd94080",
+            "language": "French",
+            "malId": 1632,
+            "name": "Lesser, Mark"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/112701.jpg?s=6983616071860c6f0c0ce268bfe5e911",
+        "malId": 2113,
+        "name": "Tama",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/112948.jpg?s=918e33cfe47ee84d921e74fb4cdcb973",
+        "malId": 3168,
+        "name": "Pan",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/43349.jpg?s=a4fd7648492641ebcf1461330ffaf22d",
+            "language": "English",
+            "malId": 41329,
+            "name": "Tirado, Jeannie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/56381.jpg?s=006be38deac7972dfd34701b71487c21",
+            "language": "Japanese",
+            "malId": 170,
+            "name": "Minaguchi, Yuko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70463.jpg?s=47bade8685f7ebb63bce40bd59b13c8c",
+            "language": "Portuguese (BR)",
+            "malId": 11595,
+            "name": "Marques, Jussara"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1283.jpg?s=58fe797c8fc4b60dc11aab8cc74dce62",
+            "language": "Italian",
+            "malId": 1291,
+            "name": "Valenti, Federica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/20825.jpg?s=b4da4e52d83749209228929984137f5c",
+            "language": "Spanish",
+            "malId": 18327,
+            "name": "Luna, Circe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/39664.jpg?s=13ddccf512eb828bdf64c65c417928fa",
+            "language": "German",
+            "malId": 22361,
+            "name": "Chakraborty, Shanti"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/32340.jpg?s=eca0a0e023cdfc81f2866ab1e473240a",
+        "malId": 6133,
+        "name": "Higashi no Kaioshin",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/58138.jpg?s=1764883e10265cc0275fef6f7486c52d",
+            "language": "Japanese",
+            "malId": 1521,
+            "name": "Oota, Shinichirou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/61900.jpg?s=e14d1173a4ab1b8d48fe3ce7c980f240",
+            "language": "Portuguese (BR)",
+            "malId": 7344,
+            "name": "Brêtas, Francisco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69785.jpg?s=831409b49d8042832e70d1b34194021a",
+            "language": "French",
+            "malId": 26645,
+            "name": "de Boüard, Vincent"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/42041.jpg?s=a363b4cd371c9be69cc7d3165de238e2",
+            "language": "German",
+            "malId": 40335,
+            "name": "Hohlbein, Hans"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46361.jpg?s=f37e3052086a12e7808c9f95fe17f17f",
+            "language": "Italian",
+            "malId": 42902,
+            "name": "Benedetti, Marco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/34701.jpg?s=4949e7a9a7b269fb394f6b75ee83ddda",
+            "language": "English",
+            "malId": 6457,
+            "name": "Vincent, David"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/40726.jpg?s=a4860e1836e7a8485ae21178dfc96389",
+            "language": "English",
+            "malId": 872,
+            "name": "Williams, Kent"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68394.jpg?s=021cbe07de790fe979d796677453cb41",
+            "language": "Spanish",
+            "malId": 57250,
+            "name": "Vásquez, Genaro"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/357381.jpg?s=5ced7a7ae823e80e4dea1079d2ddc150",
+        "malId": 154833,
+        "name": "Mosco",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58135.jpg?s=f0d78d8dd28abf06272c9d95dc16a21c",
+            "language": "Japanese",
+            "malId": 440,
+            "name": "Kishio, Daisuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67963.jpg?s=a6379a67c1d9f40bdf6a4d2b72f7f8cc",
+            "language": "Portuguese (BR)",
+            "malId": 36892,
+            "name": "Caodaglio, Marcelo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78210.jpg?s=923ae1da637a296f0b773c62d1047f58",
+            "language": "Spanish",
+            "malId": 22161,
+            "name": "Mercado Jr., Arturo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/357639.jpg?s=973021d5652a4ffe8eae545c5ca5c4ad",
+        "malId": 161787,
+        "name": "Bollarator",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/73238.jpg?s=3c5f17f828d40106993369c19465db42",
+            "language": "Spanish",
+            "malId": 56591,
+            "name": "Rojas, Tommy"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58135.jpg?s=f0d78d8dd28abf06272c9d95dc16a21c",
+            "language": "Japanese",
+            "malId": 440,
+            "name": "Kishio, Daisuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69883.jpg?s=757571c1ba6744a9324a5757133d446f",
+            "language": "Portuguese (BR)",
+            "malId": 57026,
+            "name": "Luz, Ian"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/357667.jpg?s=48e5db5694850c7493594b063d55e1d1",
+        "malId": 161785,
+        "name": "Maji Kayo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/23949.jpg?s=92ad76a45f1797ff4bb42a2bc530a269",
+            "language": "Japanese",
+            "malId": 256,
+            "name": "Shindo, Naomi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71510.jpg?s=bbd6f5a5af548437b1f31ca9f039377e",
+            "language": "Spanish",
+            "malId": 61049,
+            "name": "Morel, Sergio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/81689.jpg?s=14555db227665c0810175a9b62e72c99",
+            "language": "Portuguese (BR)",
+            "malId": 44013,
+            "name": "Borges, Silas"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/85798.jpg?s=cbd020ffd802ad6514f19a92c3ba2874",
+            "language": "Korean",
+            "malId": 86355,
+            "name": "Song, Ha-rim"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/58126.jpg?s=4695a16d5f250decf4da644727d841b9",
+            "language": "English",
+            "malId": 50422,
+            "name": "Grant, Meli"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67794.jpg?s=4889f2a9d67fbbe7f350ebbad644e909",
+            "language": "French",
+            "malId": 18873,
+            "name": "Bozo, Philippe"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/357691.jpg?s=dd137e857d49b65a9075298b6b09d7b8",
+        "malId": 161802,
+        "name": "Shantza",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69047.jpg?s=1eef0b0c38b698bb6c8d7c828e42f9d4",
+            "language": "Spanish",
+            "malId": 57717,
+            "name": "Vásquez, Gerardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67473.jpg?s=71d73804982865747e96680debef8e5f",
+            "language": "Portuguese (BR)",
+            "malId": 40349,
+            "name": "Rufino, Sérgio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68031.jpg?s=3d4e00b97ff97695c36a1e95d59498fd",
+            "language": "Japanese",
+            "malId": 348,
+            "name": "Shiraishi, Ryouko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82439.jpg?s=8530a3482a67a49979986deb7be72e25",
+            "language": "Spanish",
+            "malId": 78982,
+            "name": "Paredes, Numa"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/357694.jpg?s=2df6ac408c02e65c62070380b198fa6c",
+        "malId": 161811,
+        "name": "Sorrel",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/72997.jpg?s=4dfa228fc45958b4425556e6ed1cd749",
+            "language": "Spanish",
+            "malId": 57186,
+            "name": "Mendoza, Monserrat"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/16291.jpg?s=b465ee4faeab2e18ab8205f6f3b064f8",
+            "language": "Japanese",
+            "malId": 470,
+            "name": "Koorogi, Satomi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/52550.jpg?s=7fb8dd3d4f519b1f538d3e20878051b0",
+            "language": "Hebrew",
+            "malId": 62723,
+            "name": "Cohen, Lin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68347.jpg?s=7f791c53751feb495ad717d771c07acc",
+            "language": "Portuguese (BR)",
+            "malId": 11834,
+            "name": "Concepcion, Priscilla"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/85851.jpg?s=71b40940222ef118386af6a5425fd6c1",
+            "language": "Korean",
+            "malId": 86436,
+            "name": "Son, Seon-yeong"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1283.jpg?s=58fe797c8fc4b60dc11aab8cc74dce62",
+            "language": "Italian",
+            "malId": 1291,
+            "name": "Valenti, Federica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/46986.jpg?s=4a8121d5684974e7b1688bd30f2ccf6b",
+            "language": "English",
+            "malId": 43191,
+            "name": "Franklin, Holly"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/357695.jpg?s=a819a95c9cd916b19383dbd554bd6d51",
+        "malId": 161783,
+        "name": "The Preecho",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/47866.jpg?s=63b5532e948ce28a1e7c7e1554929a9f",
+            "language": "Spanish",
+            "malId": 44398,
+            "name": "Velázquez, Alan Fernando"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/75610.jpg?s=10ca4c1815f4e4f73145d7504b01c0a2",
+            "language": "Portuguese (BR)",
+            "malId": 5139,
+            "name": "Sawaya, Ricardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80451.jpg?s=d6b9e5474410baf9cac0f78e2cddfc93",
+            "language": "English",
+            "malId": 1602,
+            "name": "Tatum, J. Michael"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/55313.jpg?s=86be2dfeed601b343bf4a452e17b944b",
+            "language": "Japanese",
+            "malId": 488,
+            "name": "Kikuchi, Masami"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/357702.jpg?s=b8f17b16a192a1b33e080cd22bcc602a",
+        "malId": 161824,
+        "name": "Zium",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68970.jpg?s=38b881bf7f453cdc168025b6b8ea03af",
+            "language": "Spanish",
+            "malId": 57480,
+            "name": "Estrada, Héctor"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33099.jpg?s=593765acb092dfc83f74aec2bdf4cef6",
+            "language": "Japanese",
+            "malId": 1522,
+            "name": "Tatsuta, Naoki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66152.jpg?s=78aec440f9f1c805a76ce9b56fdea526",
+            "language": "Portuguese (BR)",
+            "malId": 52883,
+            "name": "Mazzei, Wilken"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/358754.jpg?s=b7f340632ffd5ad0aeaa244a0b615fbe",
+        "malId": 3182,
+        "name": "Norimaki, Arale",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/70238.jpg?s=cd90802faa19f7a1c7887c9e67c42566",
+            "language": "Spanish",
+            "malId": 39474,
+            "name": "Motta, Claudia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/48137.jpg?s=ab0f807588ec019cb989097b85ed0601",
+            "language": "English",
+            "malId": 659,
+            "name": "Palencia, Brina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70463.jpg?s=47bade8685f7ebb63bce40bd59b13c8c",
+            "language": "Portuguese (BR)",
+            "malId": 11595,
+            "name": "Marques, Jussara"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/76941.jpg?s=e08b668481d9e9fd345ee50529e4f108",
+            "language": "Japanese",
+            "malId": 571,
+            "name": "Koyama, Mami"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67476.jpg?s=ff50105bede34513c44198b231e6e6b1",
+            "language": "French",
+            "malId": 1613,
+            "name": "Lecordier, Brigitte"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82436.jpg?s=0d3773fbcad538c7a0af12b18784fb1d",
+            "language": "Spanish",
+            "malId": 78984,
+            "name": "Abad, Gema"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/358945.jpg?s=e66f7b0bb7245a25dc9bec4d6933b6a0",
+        "malId": 150836,
+        "name": "Bergamo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/34589.jpg?s=1f17c7ecd979f438359212e6468d2e03",
+            "language": "English",
+            "malId": 33799,
+            "name": "Stimac, Marcus D."
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46016.jpg?s=ce055a1a1cc688c2bc7916f703db5190",
+            "language": "Italian",
+            "malId": 42389,
+            "name": "Albertini, Stefano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68842.jpg?s=a646dfc040c765b412a67ec2689812cf",
+            "language": "Spanish",
+            "malId": 57477,
+            "name": "Castillo, Beto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/26425.jpg?s=ebe14e7cc61b5d6d98d599f400eb5e22",
+            "language": "German",
+            "malId": 23649,
+            "name": "Klemm, Matti"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47113.jpg?s=feae1bb33be3f2958c0f6a487dfcccff",
+            "language": "Portuguese (BR)",
+            "malId": 43723,
+            "name": "Loy, João"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/17723.jpg?s=a2c4e6d0ecd3e6bc09da2ec29eff64c9",
+            "language": "Japanese",
+            "malId": 576,
+            "name": "Takemoto, Eiji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/62698.jpg?s=e8ab9a46e316550e5119b570f58fe574",
+            "language": "Portuguese (BR)",
+            "malId": 43640,
+            "name": "Marchetti, César"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78330.jpg?s=a4089abf0193a1c46838f4a8dcef2bdb",
+            "language": "French",
+            "malId": 18867,
+            "name": "Peter, Eric"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/359097.jpg?s=444e959edb44bea1feec157f25cc5d65",
+        "malId": 161820,
+        "name": "Napapa",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/10693.jpg?s=28315ce100d61cbaecd8d29e120a5df5",
+            "language": "Japanese",
+            "malId": 9677,
+            "name": "Mamiya, Yasuhiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/24105.jpg?s=08936fd59a8f22078535ea1a200b6005",
+            "language": "English",
+            "malId": 9777,
+            "name": "Wald, David"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67494.jpg?s=45a31cbddbeef723c8a3ce90d6041465",
+            "language": "French",
+            "malId": 56644,
+            "name": "Atlan, Jean-Luc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68970.jpg?s=38b881bf7f453cdc168025b6b8ea03af",
+            "language": "Spanish",
+            "malId": 57480,
+            "name": "Estrada, Héctor"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/37139.jpg?s=7b1d5b35afa8f20c251de1d41b0d6af3",
+            "language": "Italian",
+            "malId": 1261,
+            "name": "De palma, Ivo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76584.jpg?s=6743a777fff90f9535442f984555fb09",
+            "language": "Portuguese (BR)",
+            "malId": 43647,
+            "name": "Abreu, Marco Antônio"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/359098.jpg?s=dc77041e350302bbc803eb63d744a194",
+        "malId": 161799,
+        "name": "Nink",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/43327.jpg?s=4b0f3a07dce588c71701af3ab84a6609",
+            "language": "English",
+            "malId": 11990,
+            "name": "Johnson, Jim"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/17723.jpg?s=a2c4e6d0ecd3e6bc09da2ec29eff64c9",
+            "language": "Japanese",
+            "malId": 576,
+            "name": "Takemoto, Eiji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/66263.jpg?s=b1e93177572a242a439cdab5bb90b3f4",
+            "language": "German",
+            "malId": 52995,
+            "name": "Aldag, Immanuel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68004.jpg?s=1bf786e0fe1fbd23770b4125583b2cbe",
+            "language": "Spanish",
+            "malId": 57253,
+            "name": "Fernández, Dafnis"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68355.jpg?s=e26149a136416971b2700fc83fa157a0",
+            "language": "Portuguese (BR)",
+            "malId": 43692,
+            "name": "Garcia, Roberto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78330.jpg?s=a4089abf0193a1c46838f4a8dcef2bdb",
+            "language": "French",
+            "malId": 18867,
+            "name": "Peter, Eric"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/359144.jpg?s=7e88f8c2e5a8081a681c6841023deebd",
+        "malId": 161771,
+        "name": "Kettol",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33097.jpg?s=66e8122478b63ad39225f1e669015277",
+            "language": "Japanese",
+            "malId": 7631,
+            "name": "Numata, Yusuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71392.jpg?s=cd257aa17be7d403c69266bb6045d127",
+            "language": "Portuguese (BR)",
+            "malId": 43709,
+            "name": "Marques, Guilherme"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/361036.jpg?s=428aad9311a29981e765952523e810b9",
+        "malId": 163382,
+        "name": "Ogma",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/6770.jpg?s=46aa3da2ebe16b7221713f7a0315f562",
+            "language": "English",
+            "malId": 859,
+            "name": "Clark, Leah"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68929.jpg?s=f257321bd063089ed5eb5b0402888dfa",
+            "language": "Italian",
+            "malId": 57628,
+            "name": "Agrillo, Dario"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/73971.jpg?s=38acd9ef92a2e0f60c19e027b03b0ad0",
+            "language": "Spanish",
+            "malId": 1686,
+            "name": "Martiñón, Isabel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/27555.jpg?s=903914a0cb5b74c26562267977d1e105",
+            "language": "Japanese",
+            "malId": 6663,
+            "name": "Urawa, Megumi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/60261.jpg?s=f030ecc72a46a450a250595103509e40",
+            "language": "Portuguese (BR)",
+            "malId": 43862,
+            "name": "Cardoso, Maria Cláudia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/366621.jpg?s=50dd64e5332955c2090cb7d57d9b6c82",
+        "malId": 165962,
+        "name": "Koichiarator",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33097.jpg?s=66e8122478b63ad39225f1e669015277",
+            "language": "Japanese",
+            "malId": 7631,
+            "name": "Numata, Yusuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58135.jpg?s=f0d78d8dd28abf06272c9d95dc16a21c",
+            "language": "Japanese",
+            "malId": 440,
+            "name": "Kishio, Daisuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58792.jpg?s=9da80c779e3d62436c37efb7dfa78735",
+            "language": "Japanese",
+            "malId": 299,
+            "name": "Nomura, Kenji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71654.jpg?s=94e8334e9be86a8212eb6f9a4646e562",
+            "language": "Spanish",
+            "malId": 61306,
+            "name": "Cárdenas, Hiram"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/371621.jpg?s=46cc8c1f69670dc6c942a9877009385b",
+        "malId": 162538,
+        "name": "Obake",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65999.jpg?s=0116de9bc2d6a5dc7754c3c27c3e3e27",
+            "language": "Portuguese (BR)",
+            "malId": 43646,
+            "name": "Alcântara, Pedro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/18159.jpg?s=3d7951b5c204e9befd0987e104267682",
+            "language": "Japanese",
+            "malId": 1675,
+            "name": "Tanaka, Ryouichi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71058.jpg?s=69078b11ad0b9cb3c62a2981b85dff34",
+            "language": "Spanish",
+            "malId": 28309,
+            "name": "Mora, Moisés Iván"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78330.jpg?s=a4089abf0193a1c46838f4a8dcef2bdb",
+            "language": "French",
+            "malId": 18867,
+            "name": "Peter, Eric"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/463735.jpg?s=773032c56c0f1ee5c9b83ad7c67c973f",
+        "malId": 205658,
+        "name": "Snake Way Guide",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80498.jpg?s=9a32ee02710cc4c72006b683add1c312",
+            "language": "English",
+            "malId": 37957,
+            "name": "Briner, Justin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76584.jpg?s=6743a777fff90f9535442f984555fb09",
+            "language": "Portuguese (BR)",
+            "malId": 43647,
+            "name": "Abreu, Marco Antônio"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/3/498109.jpg?s=db2622b315bcfa64f768a31e26308d50",
+        "malId": 170671,
+        "name": "Vegetto",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30181.jpg?s=d5dd30d9e92386e9f8d26770b8ccb838",
+            "language": "French",
+            "malId": 1150,
+            "name": "Legrand, Eric"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37125.jpg?s=3a1e02f697e98262309bca2797d0575e",
+            "language": "Italian",
+            "malId": 1087,
+            "name": "Iacono, Gianluca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67475.jpg?s=ad2f54851db7574a6ee173648bb18eb4",
+            "language": "French",
+            "malId": 39328,
+            "name": "Borg, Patrick"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68448.jpg?s=dda9297ac611a4bb2c1723b60655d11a",
+            "language": "Hebrew",
+            "malId": 63161,
+            "name": "Meir Vanunu, Avraham"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69407.jpg?s=51707e9cb717cf2dbd46b261f5ab5f0c",
+            "language": "Spanish",
+            "malId": 1698,
+            "name": "García, René"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/15759.jpg?s=9338f6a3db14b2e031e5f2c2681ccbd4",
+            "language": "Korean",
+            "malId": 14819,
+            "name": "Kim, Seung jun"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46741.jpg?s=3b9f0663cd9c6a33fab6b1d8eb77235a",
+            "language": "Portuguese (BR)",
+            "malId": 43077,
+            "name": "Feist, Henrique"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47113.jpg?s=feae1bb33be3f2958c0f6a487dfcccff",
+            "language": "Portuguese (BR)",
+            "malId": 43723,
+            "name": "Loy, João"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63540.jpg?s=4c43ddaf76aaa0d34205a2411096f13c",
+            "language": "Japanese",
+            "malId": 518,
+            "name": "Horikawa, Ryo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77340.jpg?s=2e78abe7d4d8d4fe06bc2e8bfb87fc0e",
+            "language": "Japanese",
+            "malId": 557,
+            "name": "Nozawa, Masako"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/11246.jpg?s=744c2a1513243ffd302809e5086fe736",
+            "language": "Hebrew",
+            "malId": 11970,
+            "name": "Mendelman, Ami"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/3397.jpg?s=71b6163ba268592e939307c4e235beee",
+            "language": "Korean",
+            "malId": 6499,
+            "name": "Kim, Yeong Seon"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/37157.jpg?s=37ac121dd5f6b4265263f43015e3be40",
+            "language": "Italian",
+            "malId": 1289,
+            "name": "Moneta, Claudio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+            "language": "English",
+            "malId": 253,
+            "name": "Sabat, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/69406.jpg?s=7fde89d7af43679e48098a912c4ee467",
+            "language": "Spanish",
+            "malId": 1461,
+            "name": "Castañeda, Mario"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/75915.jpg?s=316e3918010e01a30c5754942cde27b9",
+            "language": "Portuguese (BR)",
+            "malId": 1830,
+            "name": "Bezerra, Wendel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79734.jpg?s=9de7362478bc71a1eadbf32f7d249737",
+            "language": "Portuguese (BR)",
+            "malId": 7350,
+            "name": "Rollo, Alfredo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/311093.jpg?s=6cf9b23775888e2c230bcefe8b208d70",
+        "malId": 143154,
+        "name": "Zamasu",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/58205.jpg?s=1d37da5fafab7d8f66afc2078584bde4",
+            "language": "English",
+            "malId": 50467,
+            "name": "Marsters, James"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/38427.jpg?s=8761e8af68e907913b9171249ac82834",
+            "language": "Italian",
+            "malId": 7728,
+            "name": "Merluzzo, Maurizio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67240.jpg?s=8832599fd12ea2630cc6d130cf6693de",
+            "language": "Spanish",
+            "malId": 10021,
+            "name": "Vilchis, José Gilberto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70845.jpg?s=e42a999f8be9def3040f7476a82b6bbe",
+            "language": "Japanese",
+            "malId": 22,
+            "name": "Miki, Shinichiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/76479.jpg?s=32a6bd3cfa55464ce3b8c7096c1f60fd",
+            "language": "Portuguese (BR)",
+            "malId": 44291,
+            "name": "Marques, Glauco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1545.jpg?s=cd261e079460d3ec1c9dad32b0b5f00c",
+            "language": "German",
+            "malId": 1638,
+            "name": "Neumann, Viktor"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/322320.jpg?s=43e3f6c465851849c6a442d15708021f",
+        "malId": 148381,
+        "name": "Gryll",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69848.jpg?s=9c9a5e3db841aca9f2088d0f505de48b",
+            "language": "English",
+            "malId": 46748,
+            "name": "Olvera, Brienne"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71633.jpg?s=6e5bf0bb2b16cd5fb5e1a9043fff830d",
+            "language": "French",
+            "malId": 56260,
+            "name": "Ketfi, Mohamed"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68425.jpg?s=3f5cf66f52e7f6d9a6a302fdee7e92e4",
+            "language": "Spanish",
+            "malId": 57317,
+            "name": "Anaya, Raúl"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1747.jpg?s=64086c109fcb5816620332de929f131e",
+            "language": "Italian",
+            "malId": 5033,
+            "name": "Ubaldi, Pietro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48314.jpg?s=3fdefad6f93960454c1e2374990022c8",
+            "language": "Portuguese (BR)",
+            "malId": 44427,
+            "name": "Rodrigues, Zeca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/54843.jpg?s=12693f5d58d1b6cb9979fa8152b3fd9f",
+            "language": "Japanese",
+            "malId": 7914,
+            "name": "Saitou, Jirou"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/357640.jpg?s=0a34d3e680b7e94f1b12150c5bf841ed",
+        "malId": 161795,
+        "name": "Caway",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/24323.jpg?s=5e70ab7a22c401ccc0ad56b8619ab38c",
+            "language": "English",
+            "malId": 9526,
+            "name": "Ballard, Tia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/33275.jpg?s=90fad578fd93c8d7d09f9566e6e3307e",
+            "language": "Japanese",
+            "malId": 275,
+            "name": "Kouda, Mariko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/51818.jpg?s=9ca15bebc0be168ad6b408d81287a4f4",
+            "language": "Spanish",
+            "malId": 47713,
+            "name": "Robles, Jocelyn"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/63251.jpg?s=e717416240591a1c54cb4c51b6366e0e",
+            "language": "Portuguese (BR)",
+            "malId": 52955,
+            "name": "Zampieri, Michelle"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67867.jpg?s=3a4c24813082deb08f5e5ea680e269a3",
+            "language": "Italian",
+            "malId": 53058,
+            "name": "Tamburello, Martina"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/357651.jpg?s=0f454e1c0f3323d56ce50b87800ff5e2",
+        "malId": 161822,
+        "name": "Jilcol",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/24250.jpg?s=c692293faba36a68fa12aeab65ddbb95",
+            "language": "Japanese",
+            "malId": 399,
+            "name": "Iwata, Mitsuo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68004.jpg?s=1bf786e0fe1fbd23770b4125583b2cbe",
+            "language": "Spanish",
+            "malId": 57253,
+            "name": "Fernández, Dafnis"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/357652.jpg?s=28a6f04f4bb9a93485f5a2f5a9356d84",
+        "malId": 161776,
+        "name": "Jimeze",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/10693.jpg?s=28315ce100d61cbaecd8d29e120a5df5",
+            "language": "Japanese",
+            "malId": 9677,
+            "name": "Mamiya, Yasuhiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/47454.jpg?s=c4fa12f9f6aa46986073a1e3faf34c14",
+            "language": "Italian",
+            "malId": 43942,
+            "name": "Quillico, Gianni"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68970.jpg?s=38b881bf7f453cdc168025b6b8ea03af",
+            "language": "Spanish",
+            "malId": 57480,
+            "name": "Estrada, Héctor"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71392.jpg?s=cd257aa17be7d403c69266bb6045d127",
+            "language": "Portuguese (BR)",
+            "malId": 43709,
+            "name": "Marques, Guilherme"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/357659.jpg?s=3e391253b7efd4f749b5c244f54036a5",
+        "malId": 161788,
+        "name": "Koitsukai",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33097.jpg?s=66e8122478b63ad39225f1e669015277",
+            "language": "Japanese",
+            "malId": 7631,
+            "name": "Numata, Yusuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/357840.jpg?s=842c133856562825395dfc6fa5b8794a",
+        "malId": 130462,
+        "name": "Shisami",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "German",
+            "malId": 42613,
+            "name": "Müller, Andreas"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "Italian",
+            "malId": 42944,
+            "name": "Bestoso, Vittorio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/41491.jpg?s=cb0e3df332324f5ab4d9da70bf0f40e0",
+            "language": "English",
+            "malId": 19281,
+            "name": "Venable, Brad"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/41109.jpg?s=e1c0af28cb115d7f8dc6dc6c0ab1b1d9",
+            "language": "Portuguese (BR)",
+            "malId": 39446,
+            "name": "Castro, Mauro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/64837.jpg?s=6b499065d3730f1f4cfab3e06c8cbdcb",
+            "language": "Japanese",
+            "malId": 395,
+            "name": "Inada, Tetsu"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/74078.jpg?s=8457f9704df3ab9a6d33cbbec075a308",
+            "language": "Spanish",
+            "malId": 64377,
+            "name": "Ghigliazza, Miguel Ángel"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/358471.jpg?s=10498d25b8fb378002d5f59622fe667c",
+        "malId": 162261,
+        "name": "Copy Gryll",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69848.jpg?s=9c9a5e3db841aca9f2088d0f505de48b",
+            "language": "English",
+            "malId": 46748,
+            "name": "Olvera, Brienne"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71633.jpg?s=6e5bf0bb2b16cd5fb5e1a9043fff830d",
+            "language": "French",
+            "malId": 56260,
+            "name": "Ketfi, Mohamed"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58700.jpg?s=8a34321ed960a58c868e2627825fb2e3",
+            "language": "Japanese",
+            "malId": 7953,
+            "name": "Fukuhara, Kouhei"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68425.jpg?s=3f5cf66f52e7f6d9a6a302fdee7e92e4",
+            "language": "Spanish",
+            "malId": 57317,
+            "name": "Anaya, Raúl"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48314.jpg?s=3fdefad6f93960454c1e2374990022c8",
+            "language": "Portuguese (BR)",
+            "malId": 44427,
+            "name": "Rodrigues, Zeca"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/358479.jpg?s=99c7decef17ee7fcb80041a73d94b06f",
+        "malId": 7309,
+        "name": "Karin",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/73508.jpg?s=ba9d9e3e3156c4edbc6cbccde307468e",
+            "language": "Japanese",
+            "malId": 231,
+            "name": "Uo, Ken"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/75920.jpg?s=9de517a4bdacd067b8043f594013fbbf",
+            "language": "Spanish",
+            "malId": 60707,
+            "name": "Mercado, Arturo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+            "language": "English",
+            "malId": 253,
+            "name": "Sabat, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/80446.jpg?s=e0b4acc606a2a795d768758184454af4",
+            "language": "Portuguese (BR)",
+            "malId": 11695,
+            "name": "Moura, Fábio"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/358984.jpg?s=0c54161cd9408d73e8dca4e7b95f4516",
+        "malId": 677,
+        "name": "Pu'ar",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/73971.jpg?s=38acd9ef92a2e0f60c19e027b03b0ad0",
+            "language": "Spanish",
+            "malId": 1686,
+            "name": "Martiñón, Isabel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/34241.jpg?s=9dd994c6183be760808da781d61d7fdc",
+            "language": "Portuguese (BR)",
+            "malId": 13325,
+            "name": "Almeida, Rita"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/48137.jpg?s=ab0f807588ec019cb989097b85ed0601",
+            "language": "English",
+            "malId": 659,
+            "name": "Palencia, Brina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/52355.jpg?s=2e40b9214bad4af690c28d3b05ed9c52",
+            "language": "Spanish",
+            "malId": 52913,
+            "name": "Valdés, Pilar"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/65060.jpg?s=022b1f040c3747d60e958abd5252a1df",
+            "language": "Japanese",
+            "malId": 674,
+            "name": "Watanabe, Naoko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/47690.jpg?s=42ea240e6aa0d923dd86cb440a699acc",
+            "language": "German",
+            "malId": 44230,
+            "name": "Plaas-Link, Amelie"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/358998.jpg?s=e58825bc7371a9a048abbbe13fe38f38",
+        "malId": 162498,
+        "name": "Yurin",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68479.jpg?s=ab8091046da392a5a87586308db6eb39",
+            "language": "Spanish",
+            "malId": 1662,
+            "name": "Lobo, Ana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33445.jpg?s=3f4772cef4439908f3a1e943ececa408",
+            "language": "Japanese",
+            "malId": 487,
+            "name": "Maeda, Ai"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/49236.jpg?s=731f7c9032263f267b4896750d2d8301",
+            "language": "English",
+            "malId": 189,
+            "name": "Christian, Luci"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68347.jpg?s=7f791c53751feb495ad717d771c07acc",
+            "language": "Portuguese (BR)",
+            "malId": 11834,
+            "name": "Concepcion, Priscilla"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82430.jpg?s=3ad85ee14d4679494805e4e8660f522e",
+            "language": "Spanish",
+            "malId": 78988,
+            "name": "Peña, Laura"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/359286.jpg?s=42e70eeb214171b58a4f9947929c82b3",
+        "malId": 161789,
+        "name": "Paparoni",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/47200.jpg?s=22329a1ab687b1fcfaf43fceb7dd1d32",
+            "language": "English",
+            "malId": 610,
+            "name": "Bevins, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69047.jpg?s=1eef0b0c38b698bb6c8d7c828e42f9d4",
+            "language": "Spanish",
+            "malId": 57717,
+            "name": "Vásquez, Gerardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/41109.jpg?s=e1c0af28cb115d7f8dc6dc6c0ab1b1d9",
+            "language": "Portuguese (BR)",
+            "malId": 39446,
+            "name": "Castro, Mauro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/27069.jpg?s=56d4ba18460ad692885d9d10868201a3",
+            "language": "Japanese",
+            "malId": 1027,
+            "name": "Hori, Hideyuki"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/380636.jpg?s=42d04fa72fbc7738eb9a7942c528d8b5",
+        "malId": 2733,
+        "name": "Bra",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/24249.jpg?s=683c99ba6b0f35b36a08c906516394dd",
+            "language": "Japanese",
+            "malId": 354,
+            "name": "Tsuru, Hiromi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/73971.jpg?s=38acd9ef92a2e0f60c19e027b03b0ad0",
+            "language": "Spanish",
+            "malId": 1686,
+            "name": "Martiñón, Isabel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/49934.jpg?s=720ea804022eb437aa5cc43e1b8c6066",
+            "language": "Portuguese (BR)",
+            "malId": 43875,
+            "name": "Paris, Maíra"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63539.jpg?s=4de8a9d8fef1e0377095058c81114b98",
+            "language": "English",
+            "malId": 7993,
+            "name": "Landa, Lauren"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69926.jpg?s=adf76bae13be37b95c650482743621dd",
+            "language": "Portuguese (BR)",
+            "malId": 43700,
+            "name": "Giudice, Michelle"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/465444.jpg?s=d0f2cc9c28632a50eb30a3cf5d44005a",
+        "malId": 150769,
+        "name": "Jiren",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/45994.jpg?s=a0549b86e15076bbdb15f095d1298572",
+            "language": "Italian",
+            "malId": 42633,
+            "name": "Lotti, Massimiliano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/37829.jpg?s=9a681df1139a4090bec290f8010d76e7",
+            "language": "English",
+            "malId": 340,
+            "name": "Seitz, Patrick"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/6784.jpg?s=6861017a80168d3eb225b6ed3fa0771f",
+            "language": "Hungarian",
+            "malId": 9152,
+            "name": "Gacsal, Ádám"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70684.jpg?s=c8b7976c67c7b7b16820abf667e21603",
+            "language": "Spanish",
+            "malId": 56687,
+            "name": "Tinoco, Juan Carlos"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/81524.jpg?s=e937b4154864dbdf5d098ad3b9523062",
+            "language": "Portuguese (BR)",
+            "malId": 40352,
+            "name": "Tiraboschi, Armando"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/57137.jpg?s=dcd648a00d69c253148e82e9eac56052",
+            "language": "Japanese",
+            "malId": 27495,
+            "name": "Morishita, Yukiko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/63070.jpg?s=598b3356538e90461f293b56d18b0847",
+            "language": "Portuguese (BR)",
+            "malId": 45854,
+            "name": "Santana, Marina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/69152.jpg?s=7aca65fdd34fac2764769ae6459532d2",
+            "language": "Japanese",
+            "malId": 804,
+            "name": "Hanawa, Eiji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78330.jpg?s=a4089abf0193a1c46838f4a8dcef2bdb",
+            "language": "French",
+            "malId": 18867,
+            "name": "Peter, Eric"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82886.jpg?s=1cb1e1ad07b766491ca9f587674a4b0b",
+            "language": "French",
+            "malId": 55488,
+            "name": "Rehlinger, Boris"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/4/493226.jpg?s=a6038d400ade74cdf5b594c65e748275",
+        "malId": 163381,
+        "name": "Kuru",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/54964.jpg?s=c0d53a0cb2194fd78b1ea3cf62acdae0",
+            "language": "Japanese",
+            "malId": 6175,
+            "name": "Nishimura, Tomomichi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80498.jpg?s=9a32ee02710cc4c72006b683add1c312",
+            "language": "English",
+            "malId": 37957,
+            "name": "Briner, Justin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67473.jpg?s=71d73804982865747e96680debef8e5f",
+            "language": "Portuguese (BR)",
+            "malId": 40349,
+            "name": "Rufino, Sérgio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/72229.jpg?s=abc064d126be5fefd8cbfdb5cd57b3fd",
+            "language": "Portuguese (BR)",
+            "malId": 52903,
+            "name": "Ávila, Cassiano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71458.jpg?s=6895ecacd936a2e4b1cb7cf143229882",
+            "language": "Spanish",
+            "malId": 61262,
+            "name": "Garibay, Óscar"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78330.jpg?s=a4089abf0193a1c46838f4a8dcef2bdb",
+            "language": "French",
+            "malId": 18867,
+            "name": "Peter, Eric"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/285570.jpg?s=8a4d8c9bc8a59f5915c2b644c46d422a",
+        "malId": 119783,
+        "name": "Sorbet",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/36643.jpg?s=39a843ee20067af4c0399def1c4e8d4c",
+            "language": "English",
+            "malId": 35113,
+            "name": "Schwartz, Jeremy"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48555.jpg?s=e8b66333f67fe7ba0e2544995712ee12",
+            "language": "German",
+            "malId": 1218,
+            "name": "Klages, Matthias"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/73320.jpg?s=e9e8c067f50d9774341575b1565278e9",
+            "language": "Spanish",
+            "malId": 62144,
+            "name": "D'Aguillón Jr., Pedro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/45997.jpg?s=b0831a0daee83c59c0699d1c5a89506f",
+            "language": "Italian",
+            "malId": 42635,
+            "name": "Pagani, Marco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58724.jpg?s=0241898f6a96b6ba7de676a4dbcc1de8",
+            "language": "Japanese",
+            "malId": 1431,
+            "name": "Saitou, Shirou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/81524.jpg?s=e937b4154864dbdf5d098ad3b9523062",
+            "language": "Portuguese (BR)",
+            "malId": 40352,
+            "name": "Tiraboschi, Armando"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/52187.jpg?s=a6c855c7791bab6389925214579e636e",
+            "language": "Spanish",
+            "malId": 52910,
+            "name": "Tomé, Jorge"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/312402.jpg?s=efbeab2505cea4065c04d7cb9c313e31",
+        "malId": 2707,
+        "name": "Trunks",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/13701.jpg?s=57f1c8d07d1dc8036ede2f2539cf649a",
+            "language": "Italian",
+            "malId": 9994,
+            "name": "Bonetto, Monica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30851.jpg?s=c632e948d78d93d34079b32abd22b500",
+            "language": "English",
+            "malId": 9091,
+            "name": "Tipton, Alexis"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/31099.jpg?s=908047e6ef472db61c22974cd9159db1",
+            "language": "Spanish",
+            "malId": 30599,
+            "name": "Willer, Gaby"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/45514.jpg?s=d90f2c12a7f58dd020aa1a1286dc6fac",
+            "language": "Hungarian",
+            "malId": 7829,
+            "name": "Szokol, Péter"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46741.jpg?s=3b9f0663cd9c6a33fab6b1d8eb77235a",
+            "language": "Portuguese (BR)",
+            "malId": 43077,
+            "name": "Feist, Henrique"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/52355.jpg?s=2e40b9214bad4af690c28d3b05ed9c52",
+            "language": "Spanish",
+            "malId": 52913,
+            "name": "Valdés, Pilar"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/60609.jpg?s=974759f48b04bd46cdb65a2d52be805b",
+            "language": "English",
+            "malId": 25805,
+            "name": "Mendez, Erica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48350.jpg?s=c135fec99d8821fc5b418c548d307cd1",
+            "language": "German",
+            "malId": 44996,
+            "name": "Kluckert, Sebastian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/63070.jpg?s=598b3356538e90461f293b56d18b0847",
+            "language": "Portuguese (BR)",
+            "malId": 45854,
+            "name": "Santana, Marina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73596.jpg?s=36ce828518bac787c697b2b471645fac",
+            "language": "Japanese",
+            "malId": 134,
+            "name": "Kusao, Takeshi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85888.jpg?s=ebae3e39389e043b9ee26c27081fc4c5",
+            "language": "French",
+            "malId": 56315,
+            "name": "Hautbois, Anouck"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/321996.jpg?s=39d4e4ef81067168505c843685f94840",
+        "malId": 146113,
+        "name": "Galbi",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/41151.jpg?s=6ad0a3bebb7e6f9bbc2991ed814b4ca7",
+            "language": "German",
+            "malId": 40193,
+            "name": "Lochthove, Klaus"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46016.jpg?s=ce055a1a1cc688c2bc7916f703db5190",
+            "language": "Italian",
+            "malId": 42389,
+            "name": "Albertini, Stefano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/55120.jpg?s=c409277b0821693b32aea4d6be534204",
+            "language": "Japanese",
+            "malId": 945,
+            "name": "Hoshino, Mitsuaki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/72858.jpg?s=b3f1e037fe7e4c0af2eecc6aafceee6e",
+            "language": "Spanish",
+            "malId": 62365,
+            "name": "Solo, Raúl"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/23441.jpg?s=fb1ff6374c3141e831580f9cc85f0996",
+            "language": "English",
+            "malId": 1512,
+            "name": "Carter, Bob"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69876.jpg?s=f184a4147aee4e1d681f62783e8a84bf",
+            "language": "Portuguese (BR)",
+            "malId": 44292,
+            "name": "Emílio, César"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/327666.jpg?s=3b1ebccf191c5633a5d9729aca280f02",
+        "malId": 150114,
+        "name": "Vermoud",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/86792.jpg?s=4e3ad890e50872eee42f47d63c540a1d",
+            "language": "Italian",
+            "malId": 55714,
+            "name": "De Mojana, Matteo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/29895.jpg?s=b1ef43922b3a9f1a7136072d9e13c169",
+            "language": "Spanish",
+            "malId": 28307,
+            "name": "Obregón, Alfonso"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/32409.jpg?s=0d380bb32710520dd2292f0b60d74e9b",
+            "language": "English",
+            "malId": 1221,
+            "name": "Lloyd, Markus"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/55313.jpg?s=86be2dfeed601b343bf4a452e17b944b",
+            "language": "Japanese",
+            "malId": 488,
+            "name": "Kikuchi, Masami"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67794.jpg?s=4889f2a9d67fbbe7f350ebbad644e909",
+            "language": "French",
+            "malId": 18873,
+            "name": "Bozo, Philippe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/74893.jpg?s=6a3de4a1539f5d6a8470d8e22ada2ee3",
+            "language": "Portuguese (BR)",
+            "malId": 47198,
+            "name": "Reis, Henrique"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/357841.jpg?s=a9305fe04d99cfa7615451d5bc09e404",
+        "malId": 93879,
+        "name": "Yogengyo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "Italian",
+            "malId": 43441,
+            "name": "Dalla Valle, Stefano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/37923.jpg?s=404223ca84c96f83d491f45acf82eb10",
+            "language": "English",
+            "malId": 159,
+            "name": "Rial, Monica"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/24137.jpg?s=237cae03dd7639541cf16b989d394912",
+            "language": "Spanish",
+            "malId": 21205,
+            "name": "Hidalgo, Alondra"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42798.jpg?s=f8254532fc282ad2529292c7101acd07",
+            "language": "Japanese",
+            "malId": 5110,
+            "name": "Nakagawa, Shoko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/61918.jpg?s=215d32379ebdaddb7e414b71180ba519",
+            "language": "Portuguese (BR)",
+            "malId": 1445,
+            "name": "Bullara, Fernanda"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67478.jpg?s=6bb457aaa9d4318c6d130d0daf0216ad",
+            "language": "French",
+            "malId": 30739,
+            "name": "Giraudon, Marie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/9263.jpg?s=930682c263d02803d876c0f0c44b64f4",
+            "language": "German",
+            "malId": 10708,
+            "name": "Winterfeldt, Sabine"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/358748.jpg?s=63df23c0ab9f869b35b6a37abe467e01",
+        "malId": 18066,
+        "name": "Obotchaman",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/358947.jpg?s=b4acf91d20b78f24d9b5d38de331804e",
+        "malId": 151303,
+        "name": "Lavender",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69790.jpg?s=590f8695b97c595bfb32380b6156fbcc",
+            "language": "French",
+            "malId": 56660,
+            "name": "Marais, Stéphane"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/77834.jpg?s=17736d608bf712d5446e4bf1b22d7627",
+            "language": "Spanish",
+            "malId": 69480,
+            "name": "Olízar, Carlos"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/24441.jpg?s=c61dfda8d58ffa8eb69acdeb9fe67d56",
+            "language": "English",
+            "malId": 21333,
+            "name": "Guerrero, Chris"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46495.jpg?s=1870a8595b5d4d8fb8dc9664c3ad6836",
+            "language": "Italian",
+            "malId": 43000,
+            "name": "Sesana, Paolo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67558.jpg?s=fd161d2fc9f66d91d5db93343c59dacc",
+            "language": "Portuguese (BR)",
+            "malId": 43718,
+            "name": "Tatini, Adrian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73596.jpg?s=36ce828518bac787c697b2b471645fac",
+            "language": "Japanese",
+            "malId": 134,
+            "name": "Kusao, Takeshi"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/358999.jpg?s=a5815fd02c1bdbf8bec2764fc5341533",
+        "malId": 137554,
+        "name": "Cabba",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69790.jpg?s=590f8695b97c595bfb32380b6156fbcc",
+            "language": "French",
+            "malId": 56660,
+            "name": "Marais, Stéphane"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/48334.jpg?s=c8c2b38e0d10a3a93270f7076378cea6",
+            "language": "Italian",
+            "malId": 43062,
+            "name": "Lupinacci, Simone"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58135.jpg?s=f0d78d8dd28abf06272c9d95dc16a21c",
+            "language": "Japanese",
+            "malId": 440,
+            "name": "Kishio, Daisuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80353.jpg?s=4e6845c571c3ccbfa5a2d09791ed411d",
+            "language": "English",
+            "malId": 25401,
+            "name": "Chapin, Clifford"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/5124.jpg?s=9ac2ecc04ca6a7d59cf98176a890e3a1",
+            "language": "Hungarian",
+            "malId": 7858,
+            "name": "Czető, Ádám"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/69144.jpg?s=aadc0b5659753e4c7d38dbfde672838d",
+            "language": "Portuguese (BR)",
+            "malId": 43855,
+            "name": "Figueira, Daniel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73475.jpg?s=cb05908d36c59774f20e414fed0971e8",
+            "language": "Spanish",
+            "malId": 57318,
+            "name": "Treviño, Emilio"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/359004.jpg?s=bf36829bf8a656b4298db584770812d6",
+        "malId": 154829,
+        "name": "Rumsshi",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "German",
+            "malId": 64183,
+            "name": "Nothnagel, Nico"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71166.jpg?s=080271747899a0888bdcb7ddfdf0766b",
+            "language": "Spanish",
+            "malId": 60722,
+            "name": "García Alcántara, Blas"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/41109.jpg?s=e1c0af28cb115d7f8dc6dc6c0ab1b1d9",
+            "language": "Portuguese (BR)",
+            "malId": 39446,
+            "name": "Castro, Mauro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63177.jpg?s=c9011887bc42c8637c9b0e250dfca064",
+            "language": "Portuguese (BR)",
+            "malId": 46044,
+            "name": "Mendes, Vanderlan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/23483.jpg?s=eecbf2a96b038ab80d234e3e828fa418",
+            "language": "English",
+            "malId": 5361,
+            "name": "Pitts, Orion"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/40450.jpg?s=4b23fe47027b3434eeae29c5f0b16c94",
+            "language": "Japanese",
+            "malId": 7713,
+            "name": "Kawazu, Yasuhiko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/46637.jpg?s=5bc15631b7f7febc040ee3165debcb54",
+            "language": "Italian",
+            "malId": 42848,
+            "name": "Colombo, Claudio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/359059.jpg?s=5543bc34f624ea96500f7075e808ee3b",
+        "malId": 154828,
+        "name": "Sidra",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "Italian",
+            "malId": 68353,
+            "name": "Brioschi, Domenico"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/10693.jpg?s=28315ce100d61cbaecd8d29e120a5df5",
+            "language": "Japanese",
+            "malId": 9677,
+            "name": "Mamiya, Yasuhiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/23004.jpg?s=904ce7f0011054f7d6eeb7fab6db1280",
+            "language": "English",
+            "malId": 1551,
+            "name": "Dulcie, Greg"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48314.jpg?s=3fdefad6f93960454c1e2374990022c8",
+            "language": "Portuguese (BR)",
+            "malId": 44427,
+            "name": "Rodrigues, Zeca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68802.jpg?s=9b2beb26f9f86d0c9adf9a765df20b3b",
+            "language": "Spanish",
+            "malId": 57448,
+            "name": "Villeli, Alejandro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71252.jpg?s=7a8455456d186cf2cce7119bd3d7c414",
+            "language": "French",
+            "malId": 9882,
+            "name": "Pascal, Benjamin"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/359126.jpg?s=29e0054b7da08f8c892455d4e1e30211",
+        "malId": 161765,
+        "name": "Vuon",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69785.jpg?s=831409b49d8042832e70d1b34194021a",
+            "language": "French",
+            "malId": 26645,
+            "name": "de Boüard, Vincent"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77184.jpg?s=f34daec5adafcc191a942ab6d3a2d69d",
+            "language": "Portuguese (BR)",
+            "malId": 52876,
+            "name": "Cruz, Alexandre"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68004.jpg?s=1bf786e0fe1fbd23770b4125583b2cbe",
+            "language": "Spanish",
+            "malId": 57253,
+            "name": "Fernández, Dafnis"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73596.jpg?s=36ce828518bac787c697b2b471645fac",
+            "language": "Japanese",
+            "malId": 134,
+            "name": "Kusao, Takeshi"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/361041.jpg?s=bfed5f8298efd1d0c49c155718d7aa76",
+        "malId": 163387,
+        "name": "Ugg",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/28191.jpg?s=748011dfff8b56eab07765d4a8719804",
+            "language": "English",
+            "malId": 7450,
+            "name": "Bowling, Anthony"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69876.jpg?s=f184a4147aee4e1d681f62783e8a84bf",
+            "language": "Portuguese (BR)",
+            "malId": 44292,
+            "name": "Emílio, César"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/78102.jpg?s=ef2bbdfd265e16a813ec4bb5781494e5",
+            "language": "Portuguese (BR)",
+            "malId": 43859,
+            "name": "Morales, Alex"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/32419.jpg?s=45ef11409f4198f3672a8e0b85cbf153",
+            "language": "Japanese",
+            "malId": 752,
+            "name": "Takato, Yasuhiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/364659.jpg?s=f0712fbebff2d6a6843d83d145d2fd25",
+        "malId": 145291,
+        "name": "Future Mai",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30191.jpg?s=ae2728aa271ed956b5a0b72e7a047cbc",
+            "language": "English",
+            "malId": 472,
+            "name": "Clinkenbeard, Colleen"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37197.jpg?s=175302f6dc5ab008a11c0d5c2423e4db",
+            "language": "Italian",
+            "malId": 25987,
+            "name": "Bertolas, Renata"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68352.jpg?s=f4b00abdda83a02fa853cca4a52681cf",
+            "language": "Portuguese (BR)",
+            "malId": 5136,
+            "name": "Quinto, Letícia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/75685.jpg?s=ab2b3d91b1dcd7e6656b16b4a7ab232d",
+            "language": "Japanese",
+            "malId": 5763,
+            "name": "Yamada, Eiko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/32687.jpg?s=d9e617b645dbafdbee1c2f3c66d46140",
+            "language": "French",
+            "malId": 31621,
+            "name": "Ropion, Joséphine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/44898.jpg?s=1d01ff0a5328346c5909145b1ae6557f",
+            "language": "English",
+            "malId": 1065,
+            "name": "Maddalena, Julie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68840.jpg?s=e5003c3aa927bafd54db7c5d359bcfb8",
+            "language": "Spanish",
+            "malId": 57475,
+            "name": "Vázquez, Carola"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/372209.jpg?s=14bff4812a229eb79897f1c24d077905",
+        "malId": 167792,
+        "name": "Anilaza",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/47200.jpg?s=22329a1ab687b1fcfaf43fceb7dd1d32",
+            "language": "English",
+            "malId": 610,
+            "name": "Bevins, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/59500.jpg?s=3eebd7ba8c5b621572131706ecc68032",
+            "language": "Portuguese (BR)",
+            "malId": 43858,
+            "name": "Gonçalves, Renan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68970.jpg?s=38b881bf7f453cdc168025b6b8ea03af",
+            "language": "Spanish",
+            "malId": 57480,
+            "name": "Estrada, Héctor"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/88690.jpg?s=2a67ae7e8b96c19a88b83e9ef3e1c693",
+            "language": "Japanese",
+            "malId": 1481,
+            "name": "Egawa, Hisao"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/375125.jpg?s=dfee723daa759ba6480fa09fe6903b00",
+        "malId": 143844,
+        "name": "Future Trunks",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37129.jpg?s=779b89c1a4d137a20af51d309811c938",
+            "language": "Italian",
+            "malId": 774,
+            "name": "D'Andrea, Simone"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/76481.jpg?s=ec47afff0e4612189bd839b82d2d3112",
+            "language": "Portuguese (BR)",
+            "malId": 1423,
+            "name": "Campos, Marcelo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/12481.jpg?s=f3c1d0fac6b312474b1598c944d13f64",
+            "language": "English",
+            "malId": 312,
+            "name": "Vale, Eric"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/45514.jpg?s=d90f2c12a7f58dd020aa1a1286dc6fac",
+            "language": "Hungarian",
+            "malId": 7829,
+            "name": "Szokol, Péter"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46741.jpg?s=3b9f0663cd9c6a33fab6b1d8eb77235a",
+            "language": "Portuguese (BR)",
+            "malId": 43077,
+            "name": "Feist, Henrique"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/49504.jpg?s=26d1397c919f1d3a21b3cb5e42956f39",
+            "language": "Spanish",
+            "malId": 46043,
+            "name": "Bonilla Martínez, Sergio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/64048.jpg?s=902e34568da4aa6c01d1a7d11790816d",
+            "language": "English",
+            "malId": 27075,
+            "name": "Chiplock, Sean"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77477.jpg?s=3d23ccef3d344331658cb1474fbfeb09",
+            "language": "Portuguese (BR)",
+            "malId": 43704,
+            "name": "Azevedo, Fábio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/85387.jpg?s=ee901d73e2af3fc54ea6091882cf2b06",
+            "language": "Spanish",
+            "malId": 85640,
+            "name": "Rico, Bernabé"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48350.jpg?s=c135fec99d8821fc5b418c548d307cd1",
+            "language": "German",
+            "malId": 44996,
+            "name": "Kluckert, Sebastian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67477.jpg?s=f384463922bbc87d964785549bd94080",
+            "language": "French",
+            "malId": 1632,
+            "name": "Lesser, Mark"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73596.jpg?s=36ce828518bac787c697b2b471645fac",
+            "language": "Japanese",
+            "malId": 134,
+            "name": "Kusao, Takeshi"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/380621.jpg?s=7ed25ae5823eea3aae527029f951261d",
+        "malId": 170677,
+        "name": "Gattai Zamasu",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/58205.jpg?s=1d37da5fafab7d8f66afc2078584bde4",
+            "language": "English",
+            "malId": 50467,
+            "name": "Marsters, James"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67240.jpg?s=8832599fd12ea2630cc6d130cf6693de",
+            "language": "Spanish",
+            "malId": 10021,
+            "name": "Vilchis, José Gilberto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70845.jpg?s=e42a999f8be9def3040f7476a82b6bbe",
+            "language": "Japanese",
+            "malId": 22,
+            "name": "Miki, Shinichiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/76479.jpg?s=32a6bd3cfa55464ce3b8c7096c1f60fd",
+            "language": "Portuguese (BR)",
+            "malId": 44291,
+            "name": "Marques, Glauco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1545.jpg?s=cd261e079460d3ec1c9dad32b0b5f00c",
+            "language": "German",
+            "malId": 1638,
+            "name": "Neumann, Viktor"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/400410.jpg?s=ca7fe693a6024ae923016dd7b0d6c94d",
+        "malId": 157075,
+        "name": "Kefla",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/25963.jpg?s=1fa9c097ae8f09f03bf8f4e124468e0b",
+            "language": "Spanish",
+            "malId": 22589,
+            "name": "Leal, Lupita"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/43957.jpg?s=09918392e6942711f21a261b48c7c3f5",
+            "language": "English",
+            "malId": 38428,
+            "name": "Bennett, Dawn M."
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67175.jpg?s=9b46a1dffbb23027560211a2e552b00b",
+            "language": "French",
+            "malId": 56436,
+            "name": "Virtudes, Brigitte"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68312.jpg?s=9423543c02840f0a8cfa913a7e2e781e",
+            "language": "Spanish",
+            "malId": 57224,
+            "name": "Orozco, Andrea"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69924.jpg?s=3beaf1bce9580137c405bfe60ccc93bc",
+            "language": "Portuguese (BR)",
+            "malId": 11403,
+            "name": "Paulita, Flora"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/87352.jpg?s=24aff92eead1368b242b6b8afdb4339b",
+            "language": "Japanese",
+            "malId": 140,
+            "name": "Yukana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/49242.jpg?s=7a7f209e6414f65664f03d8207372870",
+            "language": "English",
+            "malId": 30375,
+            "name": "Maxwell, Elizabeth"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/54465.jpg?s=93788ed7d901254bf1cd9a7dbcfd7a33",
+            "language": "Japanese",
+            "malId": 9858,
+            "name": "Komatsu, Yuka"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73129.jpg?s=dfa67b1cdeb0b8c6162a5809ef6908c5",
+            "language": "Portuguese (BR)",
+            "malId": 5178,
+            "name": "Fernandes, Samira"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/65195.jpg?s=00f7c13fc7e57fb8b2ead76f83dc08aa",
+        "malId": 6273,
+        "name": "Dende",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "Italian",
+            "malId": 42861,
+            "name": "Calvetti, Giuseppe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80501.jpg?s=ee808f428c434aee43fe003623f6bf0b",
+            "language": "English",
+            "malId": 203,
+            "name": "Cook, Justin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/73462.jpg?s=a2564a862bc79698246db8d77d6cbcc9",
+            "language": "Spanish",
+            "malId": 31859,
+            "name": "Olguín, Javier"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/79361.jpg?s=ef28eff7e0907a36884f8f7519ef087a",
+            "language": "Portuguese (BR)",
+            "malId": 45410,
+            "name": "Martins, Gabriel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/85347.jpg?s=a2d569f3b248a2ce8a30e4740b0de1bb",
+            "language": "German",
+            "malId": 36980,
+            "name": "Zeiger, Christian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67478.jpg?s=6bb457aaa9d4318c6d130d0daf0216ad",
+            "language": "French",
+            "malId": 30739,
+            "name": "Giraudon, Marie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78608.jpg?s=38b29d5c7ac8810fcadb50be79c87eb9",
+            "language": "Japanese",
+            "malId": 4,
+            "name": "Hirano, Aya"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/81041.jpg?s=67cca1146c49222471cfbf7fc92e0a83",
+            "language": "Portuguese (BR)",
+            "malId": 5084,
+            "name": "Andreatto, Rodrigo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/5/73079.jpg?s=049e14cf371c4d151da946a2066b5627",
+        "malId": 9393,
+        "name": "King Vegeta",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/41109.jpg?s=e1c0af28cb115d7f8dc6dc6c0ab1b1d9",
+            "language": "Portuguese (BR)",
+            "malId": 39446,
+            "name": "Castro, Mauro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/59539.jpg?s=b85ed1b2a4522a06a0c5390ac18d3b42",
+            "language": "Japanese",
+            "malId": 5386,
+            "name": "Satou, Masaharu"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68793.jpg?s=7e20a9b8e4e3d7e587965c848bd425b1",
+            "language": "Spanish",
+            "malId": 57438,
+            "name": "Reyes, Salvador"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1747.jpg?s=64086c109fcb5816620332de929f131e",
+            "language": "Italian",
+            "malId": 5033,
+            "name": "Ubaldi, Pietro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+            "language": "English",
+            "malId": 253,
+            "name": "Sabat, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/70718.jpg?s=ffbed4cb58ddfa2c9a4b2dd85a4c02d1",
+            "language": "English",
+            "malId": 351,
+            "name": "McConnohie, Michael"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/295131.jpg?s=8bd588405230248d3b34a00958613e74",
+        "malId": 135265,
+        "name": "Vados",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/36785.jpg?s=27dbb4c3f58b1323d5361196cdba22fe",
+            "language": "German",
+            "malId": 30261,
+            "name": "Winterfeldt, Giovanna"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/15553.jpg?s=19a8906c1ca33350a521145688fda972",
+            "language": "Italian",
+            "malId": 1088,
+            "name": "Magnaghi, Debora"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/40237.jpg?s=f9426183b369d4260c18b27dc486dfcb",
+            "language": "English",
+            "malId": 313,
+            "name": "Glass, Caitlin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63904.jpg?s=4018e7554b1535d2fd702398a231b1aa",
+            "language": "Japanese",
+            "malId": 130,
+            "name": "Yamaguchi, Yuriko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/6467.jpg?s=0d1391db9a69463db299e6a560c1b830",
+            "language": "Hungarian",
+            "malId": 8961,
+            "name": "Csifó, Dorina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69146.jpg?s=81cfbb8f368c1cf89674b3aac0ebbbcf",
+            "language": "Portuguese (BR)",
+            "malId": 14483,
+            "name": "Franco, Priscila"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/73311.jpg?s=8900bd58fc91d164f689c3c9674bddda",
+            "language": "Spanish",
+            "malId": 11623,
+            "name": "Marroquín Payró, Romina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/85798.jpg?s=cbd020ffd802ad6514f19a92c3ba2874",
+            "language": "Korean",
+            "malId": 86355,
+            "name": "Song, Ha-rim"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/65119.jpg?s=3fa4bb4ab3c71f68a0c5faed77a9e8a7",
+            "language": "English",
+            "malId": 44506,
+            "name": "Ryan, Tamara"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67478.jpg?s=6bb457aaa9d4318c6d130d0daf0216ad",
+            "language": "French",
+            "malId": 30739,
+            "name": "Giraudon, Marie"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/298385.jpg?s=4d77e3d73b25bbb8c9a98ed612aa9a9c",
+        "malId": 137552,
+        "name": "Monaka",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48658.jpg?s=7d876fc697a870a2470684c5416f0f31",
+            "language": "English",
+            "malId": 36888,
+            "name": "Mills, Daman"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/59598.jpg?s=f88827b55134ca0140fac024ec9a2aff",
+            "language": "Portuguese (BR)",
+            "malId": 43860,
+            "name": "Dias, Bruno"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69785.jpg?s=831409b49d8042832e70d1b34194021a",
+            "language": "French",
+            "malId": 26645,
+            "name": "de Boüard, Vincent"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70632.jpg?s=00bb50f8c10d7990d528c178eeccd57c",
+            "language": "Spanish",
+            "malId": 60157,
+            "name": "Mendiola, Roberto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/28043.jpg?s=5dcc6c0839aea53034003af4e52ad1fe",
+            "language": "Hungarian",
+            "malId": 7763,
+            "name": "Baráth, István"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/55313.jpg?s=86be2dfeed601b343bf4a452e17b944b",
+            "language": "Japanese",
+            "malId": 488,
+            "name": "Kikuchi, Masami"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/305144.jpg?s=bd78e16288d4c9b7f8f3459cc93d7304",
+        "malId": 133279,
+        "name": "Pirozhki",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/38702.jpg?s=4787dbfdcce1b482a18261660cb67956",
+            "language": "English",
+            "malId": 336,
+            "name": "Hebert, Kyle"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/47220.jpg?s=f0f739b0e64d229ec1ab39a9af5420a9",
+            "language": "German",
+            "malId": 43541,
+            "name": "Wittorf, Marco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80923.jpg?s=7886e356cc102a1e3faeb7e2e186a0dd",
+            "language": "Spanish",
+            "malId": 75577,
+            "name": "Zavala, Ulises Maynardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/88690.jpg?s=2a67ae7e8b96c19a88b83e9ef3e1c693",
+            "language": "Japanese",
+            "malId": 1481,
+            "name": "Egawa, Hisao"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48314.jpg?s=3fdefad6f93960454c1e2374990022c8",
+            "language": "Portuguese (BR)",
+            "malId": 44427,
+            "name": "Rodrigues, Zeca"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/357638.jpg?s=38a4c0d11ded80b4be5ded9193adca5f",
+        "malId": 161805,
+        "name": "Dr. Rota",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30935.jpg?s=df47c5bb3c7fc55fdc064357638fe218",
+            "language": "Portuguese (BR)",
+            "malId": 29167,
+            "name": "Camilo, Leonardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46016.jpg?s=ce055a1a1cc688c2bc7916f703db5190",
+            "language": "Italian",
+            "malId": 42389,
+            "name": "Albertini, Stefano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63576.jpg?s=eb699ac5ae1bf46f704615a9ca844409",
+            "language": "Spanish",
+            "malId": 54176,
+            "name": "Colmenero, Francisco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/43236.jpg?s=28601632421d35f3239db2af6c584065",
+            "language": "English",
+            "malId": 11259,
+            "name": "Horvitz, Richard"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/55313.jpg?s=86be2dfeed601b343bf4a452e17b944b",
+            "language": "Japanese",
+            "malId": 488,
+            "name": "Kikuchi, Masami"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/66403.jpg?s=0c8cfa54bafdf0ac99fc1baa9eaff473",
+            "language": "French",
+            "malId": 56071,
+            "name": "Luccioni, José"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/357647.jpg?s=089589bbb836b631ea382ff2cfe7d83a",
+        "malId": 161794,
+        "name": "Ganos",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/16299.jpg?s=b29def98aef2be81fe7574127c843189",
+            "language": "Japanese",
+            "malId": 1526,
+            "name": "Miura, Hiroaki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65999.jpg?s=0116de9bc2d6a5dc7754c3c27c3e3e27",
+            "language": "Portuguese (BR)",
+            "malId": 43646,
+            "name": "Alcântara, Pedro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/81272.jpg?s=7335d18edec13299c5f1f5daf0807f88",
+            "language": "English",
+            "malId": 40413,
+            "name": "McInnis, Brandon"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71252.jpg?s=7a8455456d186cf2cce7119bd3d7c414",
+            "language": "French",
+            "malId": 9882,
+            "name": "Pascal, Benjamin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/88631.jpg?s=7b006bdf55cb52d48923ef775acd321f",
+            "language": "Portuguese (BR)",
+            "malId": 9613,
+            "name": "Guarnieri, José Otávio"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/357697.jpg?s=dc52e27fe7194b3a319204b1ceea6d48",
+        "malId": 161790,
+        "name": "Viara",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/54964.jpg?s=c0d53a0cb2194fd78b1ea3cf62acdae0",
+            "language": "Japanese",
+            "malId": 6175,
+            "name": "Nishimura, Tomomichi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/81573.jpg?s=fd67cce241e69b92a3bbd28596bd0202",
+            "language": "Portuguese (BR)",
+            "malId": 43825,
+            "name": "Porto, Paulo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/357858.jpg?s=d8e87933df6d1bb2a37389e483bef6d2",
+        "malId": 119781,
+        "name": "Tagoma",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/62866.jpg?s=e273d6a6437551b8442159357c4018bd",
+            "language": "Japanese",
+            "malId": 123,
+            "name": "Nakai, Kazuya"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69790.jpg?s=590f8695b97c595bfb32380b6156fbcc",
+            "language": "French",
+            "malId": 56660,
+            "name": "Marais, Stéphane"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/73476.jpg?s=388da836e474ef847634b5652572cdff",
+            "language": "Spanish",
+            "malId": 60378,
+            "name": "Tejedo, Ricardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80600.jpg?s=242d4f91d647eccf9d97a0d313c1ca45",
+            "language": "English",
+            "malId": 8686,
+            "name": "Solusod, Micah"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77477.jpg?s=3d23ccef3d344331658cb1474fbfeb09",
+            "language": "Portuguese (BR)",
+            "malId": 43704,
+            "name": "Azevedo, Fábio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/16849.jpg?s=1417b79f4728a17ef80f3e8ce03d68b1",
+            "language": "Italian",
+            "malId": 11920,
+            "name": "Bottale, Luca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48066.jpg?s=f672593aed809d908472bc986e811ec5",
+            "language": "German",
+            "malId": 44657,
+            "name": "Strecker, Otto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85386.jpg?s=64e9e78aa21e52d8e4e696faf728700b",
+            "language": "Spanish",
+            "malId": 85639,
+            "name": "Prieto, Paco"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/358662.jpg?s=98bc518fda8b1ce7883636f9b7f9fbab",
+        "malId": 2112,
+        "name": "Umikame",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/17219.jpg?s=7fa6c270b98c6fbc446c2af28acf3458",
+            "language": "Japanese",
+            "malId": 10063,
+            "name": "Fujimoto, Takahiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48314.jpg?s=3fdefad6f93960454c1e2374990022c8",
+            "language": "Portuguese (BR)",
+            "malId": 44427,
+            "name": "Rodrigues, Zeca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/52187.jpg?s=a6c855c7791bab6389925214579e636e",
+            "language": "Spanish",
+            "malId": 52910,
+            "name": "Tomé, Jorge"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/358892.jpg?s=d35cc04b0c255b8115dde0eb4c8134bd",
+        "malId": 149345,
+        "name": "Amaguri, Cocoa",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/40982.jpg?s=bb21d44d2c56d482fc1b20c14057499e",
+            "language": "English",
+            "malId": 30379,
+            "name": "Apprill, Bryn"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/70077.jpg?s=19cf1583d5d2caa66227106cb8c3f525",
+            "language": "Spanish",
+            "malId": 59218,
+            "name": "Arruti, Andrea"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/57708.jpg?s=14507772a7d4efb4741e0fbd7eedfafd",
+            "language": "Japanese",
+            "malId": 77,
+            "name": "Asano, Masumi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/36819.jpg?s=1f93482483e04ec21b6608c471a0c485",
+            "language": "Italian",
+            "malId": 35383,
+            "name": "Pallavicino, Valentina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67478.jpg?s=6bb457aaa9d4318c6d130d0daf0216ad",
+            "language": "French",
+            "malId": 30739,
+            "name": "Giraudon, Marie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/80655.jpg?s=1119dc06bfe1bb614a9530fda5b13504",
+            "language": "Portuguese (BR)",
+            "malId": 52907,
+            "name": "Evangelista, Mariana"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/359001.jpg?s=b0f6c285cdf733f32738264f42ebdd2f",
+        "malId": 6167,
+        "name": "Muten-Roushi",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48404.jpg?s=c5aea697eef1be222d54317a2167c674",
+            "language": "German",
+            "malId": 45040,
+            "name": "Kästner, Thomas"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/6762.jpg?s=c7b1ee9ee01ac674474ff6547df4e1a8",
+            "language": "English",
+            "malId": 202,
+            "name": "McFarland, Mike"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/16923.jpg?s=f1663bcdf18677261153caa342556f27",
+            "language": "Spanish",
+            "malId": 15619,
+            "name": "Peña, Mariano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/40780.jpg?s=c67d95bc4d7d9140ad5bbae02a589fb4",
+            "language": "English",
+            "malId": 232,
+            "name": "Thornton, Kirk"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/59539.jpg?s=b85ed1b2a4522a06a0c5390ac18d3b42",
+            "language": "Japanese",
+            "malId": 5386,
+            "name": "Satou, Masaharu"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/62272.jpg?s=4e68660fec866b89eb12391d0151c9ef",
+            "language": "Portuguese (BR)",
+            "malId": 15323,
+            "name": "Santoro, Gileno"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1240.jpg?s=5d4e9921ec240b87a0023b11054879ca",
+            "language": "Italian",
+            "malId": 1240,
+            "name": "Scarabelli, Mario"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/359280.jpg?s=1268f1d45f159db89af383874b9737f0",
+        "malId": 161800,
+        "name": "Majora",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48193.jpg?s=9ee5eccfe393ed34cefc0b683040677b",
+            "language": "English",
+            "malId": 22629,
+            "name": "Wehkamp, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/75610.jpg?s=10ca4c1815f4e4f73145d7504b01c0a2",
+            "language": "Portuguese (BR)",
+            "malId": 5139,
+            "name": "Sawaya, Ricardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/24250.jpg?s=c692293faba36a68fa12aeab65ddbb95",
+            "language": "Japanese",
+            "malId": 399,
+            "name": "Iwata, Mitsuo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/28043.jpg?s=5dcc6c0839aea53034003af4e52ad1fe",
+            "language": "Hungarian",
+            "malId": 7763,
+            "name": "Baráth, István"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/47853.jpg?s=ce9b564855c5d1cb252c11fb05d988b4",
+            "language": "Spanish",
+            "malId": 13263,
+            "name": "Matus, Edson"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82886.jpg?s=1cb1e1ad07b766491ca9f587674a4b0b",
+            "language": "French",
+            "malId": 55488,
+            "name": "Rehlinger, Boris"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/511901.jpg?s=b1adf4ef9d3b27216ceb41bee9edcc3b",
+        "malId": 230011,
+        "name": "Watagash",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/6/94545.jpg?s=e94f09be98d06f74ce14862c58394224",
+        "malId": 1012,
+        "name": "Majin Buu",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/26771.jpg?s=e87d9762c41b95d56b95b083a634f109",
+            "language": "Japanese",
+            "malId": 906,
+            "name": "Shioya, Kouzou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67475.jpg?s=ad2f54851db7574a6ee173648bb18eb4",
+            "language": "French",
+            "malId": 39328,
+            "name": "Borg, Patrick"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/3570.jpg?s=9c9f8d2a9d2ef5e87319f46320590ce1",
+            "language": "Italian",
+            "malId": 6797,
+            "name": "Rovatti, Riccardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/36487.jpg?s=1cba3de55c3f166f8f322914de2c6518",
+            "language": "English",
+            "malId": 150,
+            "name": "Spencer, Spike"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77173.jpg?s=b2cbd78bbaa33c44fc94abe68e2c1822",
+            "language": "Korean",
+            "malId": 68469,
+            "name": "Shim, Gyu-hyeok"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/39705.jpg?s=0fcd230e2577137533b2bd8bcafb42a7",
+            "language": "English",
+            "malId": 12025,
+            "name": "Martin, Josh"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/47635.jpg?s=53b2ed6eaf38b3ffde0caccd8866a3b8",
+            "language": "German",
+            "malId": 44115,
+            "name": "Büschken, Uwe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/60262.jpg?s=5c7ea79d6f0cac04c873185e09cb31ae",
+            "language": "Portuguese (BR)",
+            "malId": 7974,
+            "name": "Lima, Wellington"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82897.jpg?s=631b6bb733429a2f222e642bbb860e96",
+            "language": "Spanish",
+            "malId": 10020,
+            "name": "Patiño, Marcos"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/157417.jpg?s=8fc3022d83b5888c988ceb119638fb41",
+        "malId": 58439,
+        "name": "Gala",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/166291.jpg?s=494bbcdd7d4684333c20509b4dbd0762",
+        "malId": 62521,
+        "name": "Sarada, Kinoko",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/297606.jpg?s=fca4babc7664d457e9cd53a0b9600094",
+        "malId": 13663,
+        "name": "Suppaman",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/298389.jpg?s=e8758cda4b1656746b9f5889e5fde979",
+        "malId": 137556,
+        "name": "Botamo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67264.jpg?s=117a02572c1c725264d960b96f7adfad",
+            "language": "Italian",
+            "malId": 56487,
+            "name": "Moronesi, Marcello"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47113.jpg?s=feae1bb33be3f2958c0f6a487dfcccff",
+            "language": "Portuguese (BR)",
+            "malId": 43723,
+            "name": "Loy, João"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/81680.jpg?s=4ed4cee47408e765901cb9d67c6ee3e3",
+            "language": "Spanish",
+            "malId": 77491,
+            "name": "Rocha, Ricardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/32419.jpg?s=45ef11409f4198f3672a8e0b85cbf153",
+            "language": "Japanese",
+            "malId": 752,
+            "name": "Takato, Yasuhiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/40463.jpg?s=ed9bd2d7ed7787b77e5c09ecbef5adb7",
+            "language": "English",
+            "malId": 19809,
+            "name": "George, Cris"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/52187.jpg?s=a6c855c7791bab6389925214579e636e",
+            "language": "Spanish",
+            "malId": 52910,
+            "name": "Tomé, Jorge"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/77320.jpg?s=9e9bbfe4f055904a5259a8ee0ac9da28",
+            "language": "Portuguese (BR)",
+            "malId": 34845,
+            "name": "Campos, Fábio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/9678.jpg?s=d0847e38dac1c51b1d15992048ffd6a7",
+            "language": "Italian",
+            "malId": 1276,
+            "name": "Battezzato, Giovanni"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/306940.jpg?s=41a4322326a0fdcb17de3338978814ae",
+        "malId": 141729,
+        "name": "Gokuu Black",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/42833.jpg?s=4333bd5e0eeb42a25b312aec15072e4c",
+            "language": "English",
+            "malId": 1000,
+            "name": "Schemmel, Sean"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/50634.jpg?s=62712c71d5bc89040e867e1066a5caf8",
+            "language": "Spanish",
+            "malId": 46859,
+            "name": "Domínguez, Pablo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67475.jpg?s=ad2f54851db7574a6ee173648bb18eb4",
+            "language": "French",
+            "malId": 39328,
+            "name": "Borg, Patrick"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68448.jpg?s=dda9297ac611a4bb2c1723b60655d11a",
+            "language": "Hebrew",
+            "malId": 63161,
+            "name": "Meir Vanunu, Avraham"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46741.jpg?s=3b9f0663cd9c6a33fab6b1d8eb77235a",
+            "language": "Portuguese (BR)",
+            "malId": 43077,
+            "name": "Feist, Henrique"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77340.jpg?s=2e78abe7d4d8d4fe06bc2e8bfb87fc0e",
+            "language": "Japanese",
+            "malId": 557,
+            "name": "Nozawa, Masako"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/3397.jpg?s=71b6163ba268592e939307c4e235beee",
+            "language": "Korean",
+            "malId": 6499,
+            "name": "Kim, Yeong Seon"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/37157.jpg?s=37ac121dd5f6b4265263f43015e3be40",
+            "language": "Italian",
+            "malId": 1289,
+            "name": "Moneta, Claudio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/5053.jpg?s=7e72bfb86fc29b38368d2a14e43afc17",
+            "language": "Hungarian",
+            "malId": 7798,
+            "name": "Lippai, László"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/69406.jpg?s=7fde89d7af43679e48098a912c4ee467",
+            "language": "Spanish",
+            "malId": 1461,
+            "name": "Castañeda, Mario"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/75915.jpg?s=316e3918010e01a30c5754942cde27b9",
+            "language": "Portuguese (BR)",
+            "malId": 1830,
+            "name": "Bezerra, Wendel"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/340119.jpg?s=b0536e16ad61f4b2503785ab10d800da",
+        "malId": 150922,
+        "name": "Daishinkan",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/29709.jpg?s=78350ef97aa8e9fd394d803c2937f3c9",
+            "language": "English",
+            "malId": 1047,
+            "name": "Grelle, Jessie James"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/55769.jpg?s=5a7d04a4bbf2bbd93d8740ae0f3f9efa",
+            "language": "Spanish",
+            "malId": 60296,
+            "name": "Garrido, Salvi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/64740.jpg?s=93a317325d77ac84ee15cfb502b15b48",
+            "language": "Portuguese (BR)",
+            "malId": 11521,
+            "name": "Chesman, Yuri"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68835.jpg?s=8f3edb60bc419923da9f9a5c8dd9709e",
+            "language": "Spanish",
+            "malId": 57470,
+            "name": "Arenas, José"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/70030.jpg?s=72542a9618480003a8e821a231520ce2",
+            "language": "Italian",
+            "malId": 42869,
+            "name": "Bressan, Mattia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/88034.jpg?s=82dad37fd844ac0473d58f1e283e2cd1",
+            "language": "Japanese",
+            "malId": 1832,
+            "name": "Takatsuka, Masaya"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/357369.jpg?s=8b0869134d169429412e50ca368f4704",
+        "malId": 154837,
+        "name": "Cognac",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/358898.jpg?s=eaba8059e4d50206e692dd6c57e893cd",
+        "malId": 162452,
+        "name": "Kahn, Barry",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69785.jpg?s=831409b49d8042832e70d1b34194021a",
+            "language": "French",
+            "malId": 26645,
+            "name": "de Boüard, Vincent"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/80258.jpg?s=59afcfa15633b6a2dfb2c62a0c74bb49",
+            "language": "Portuguese (BR)",
+            "malId": 21199,
+            "name": "Zilse, Felipe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/10862.jpg?s=cff5bf6118c8b109868c0ce3b3d8db13",
+            "language": "Japanese",
+            "malId": 257,
+            "name": "Hiyama, Nobuyuki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/43298.jpg?s=ca8ba8819be453db013e3b6f095c9133",
+            "language": "English",
+            "malId": 666,
+            "name": "McCollum, Robert"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/32519.jpg?s=a6ed270fac2dff8217ad658f8b3aaf26",
+            "language": "Italian",
+            "malId": 20082,
+            "name": "Andreozzi, Ruggero"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/359258.jpg?s=9283da1c6156a10c96ca75d71522d62d",
+        "malId": 3694,
+        "name": "Freeza",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/16259.jpg?s=5f396438066d4fc18bb54f080c0b0601",
+            "language": "English",
+            "malId": 191,
+            "name": "Ayres, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/42527.jpg?s=25648795af594071cb0a9872d9851932",
+            "language": "Spanish",
+            "malId": 40377,
+            "name": "Corpa, Ángel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/48658.jpg?s=7d876fc697a870a2470684c5416f0f31",
+            "language": "English",
+            "malId": 36888,
+            "name": "Mills, Daman"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65678.jpg?s=492c982f157200ceb1c87c3e7d5c72d3",
+            "language": "Japanese",
+            "malId": 259,
+            "name": "Nakao, Ryusei"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/40745.jpg?s=591ba292d84ec5e9d7d1b5596f3a6668",
+            "language": "Portuguese (BR)",
+            "malId": 14487,
+            "name": "Campanile, Carlos"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/44411.jpg?s=3d2a27b5b55f6aeb2688dd3cab1cf581",
+            "language": "French",
+            "malId": 39332,
+            "name": "Ariotti, Philippe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/65118.jpg?s=1276e1d4e14a671d299dafac28b91ede",
+            "language": "Italian",
+            "malId": 1283,
+            "name": "Zanandrea, Federico"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/75912.jpg?s=f436f8ac7763d8c42b2257bc39113b42",
+            "language": "Spanish",
+            "malId": 10024,
+            "name": "Reyero, Gerardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/41281.jpg?s=9cdd7f3211e68f90b3f2dfa9958585e1",
+            "language": "English",
+            "malId": 390,
+            "name": "Prince, Derek Stephen"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/43364.jpg?s=bc7be2cdf4cc37f006ab8594d6f09adc",
+            "language": "German",
+            "malId": 11911,
+            "name": "Schmuckert, Thomas"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/359281.jpg?s=971f3315ea86de22f67335cb681e3300",
+        "malId": 150282,
+        "name": "Marcarita",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/44905.jpg?s=9951235d6babb6c1c1ac9e6d4998316d",
+            "language": "French",
+            "malId": 24241,
+            "name": "Fauveau, Jennifer"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/53239.jpg?s=f679df33ebb335d65af141159a6ff900",
+            "language": "Japanese",
+            "malId": 48161,
+            "name": "Sasaki, Ai"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/49934.jpg?s=720ea804022eb437aa5cc43e1b8c6066",
+            "language": "Portuguese (BR)",
+            "malId": 43875,
+            "name": "Paris, Maíra"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/51781.jpg?s=7a0cac28da0ad8f64e00a4e0040cc09d",
+            "language": "Spanish",
+            "malId": 47672,
+            "name": "Sánchez, Analiz"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/55575.jpg?s=5402e11bc4dda07181f4e1d08dbbe13f",
+            "language": "English",
+            "malId": 891,
+            "name": "Marchi, Jamie"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/74407.jpg?s=9bf923e68823fbb869f633484f5dab86",
+            "language": "Italian",
+            "malId": 35767,
+            "name": "Felli, Martina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/82439.jpg?s=8530a3482a67a49979986deb7be72e25",
+            "language": "Spanish",
+            "malId": 78982,
+            "name": "Paredes, Numa"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/359290.jpg?s=6622ff6943dbec13a07d7b3bbcca4b37",
+        "malId": 161768,
+        "name": "Tupper",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/52507.jpg?s=a459ed08aa24c17e7fc07d0b44726e56",
+            "language": "Japanese",
+            "malId": 47668,
+            "name": "Volcano Ota"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/72858.jpg?s=b3f1e037fe7e4c0af2eecc6aafceee6e",
+            "language": "Spanish",
+            "malId": 62365,
+            "name": "Solo, Raúl"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63177.jpg?s=c9011887bc42c8637c9b0e250dfca064",
+            "language": "Portuguese (BR)",
+            "malId": 46044,
+            "name": "Mendes, Vanderlan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80451.jpg?s=d6b9e5474410baf9cac0f78e2cddfc93",
+            "language": "English",
+            "malId": 1602,
+            "name": "Tatum, J. Michael"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78330.jpg?s=a4089abf0193a1c46838f4a8dcef2bdb",
+            "language": "French",
+            "malId": 18867,
+            "name": "Peter, Eric"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/364678.jpg?s=e9b313ec44a066714467454ceb32654c",
+        "malId": 163378,
+        "name": "Pell",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/26771.jpg?s=e87d9762c41b95d56b95b083a634f109",
+            "language": "Japanese",
+            "malId": 906,
+            "name": "Shioya, Kouzou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/1137.jpg?s=8e6074d391f0dcc03a827730c0a241ef",
+            "language": "Italian",
+            "malId": 1093,
+            "name": "Paiola, Antonio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/41109.jpg?s=e1c0af28cb115d7f8dc6dc6c0ab1b1d9",
+            "language": "Portuguese (BR)",
+            "malId": 39446,
+            "name": "Castro, Mauro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/61712.jpg?s=48384b6beb831269bad6705308005124",
+            "language": "Portuguese (BR)",
+            "malId": 44841,
+            "name": "José, Leonardo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/44762.jpg?s=0a164546d0ee36b5b183417cf1493f34",
+        "malId": 2098,
+        "name": "Jinzouningen 8-gou",
+        "role": "Supporting",
+        "voiceActors": []
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/45213.jpg?s=2c85af9da505cfc6ba502fbf80d6387b",
+        "malId": 2100,
+        "name": "Bee",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/30771.jpg?s=61e1ebc623b16ffd76e101dd353d9236",
+            "language": "Japanese",
+            "malId": 328,
+            "name": "Suzuki, Masami"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/45234.jpg?s=f78510e53dc01e4babb6fa68fd2b8117",
+        "malId": 9785,
+        "name": "Bubbles",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "German",
+            "malId": 46576,
+            "name": "Nagy, Márton"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/17219.jpg?s=7fa6c270b98c6fbc446c2af28acf3458",
+            "language": "Japanese",
+            "malId": 10063,
+            "name": "Fujimoto, Takahiro"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/50611.jpg?s=3465f2d57eabc011d155724dd1b8f813",
+            "language": "Spanish",
+            "malId": 46818,
+            "name": "Hidalgo, Alberto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/11246.jpg?s=744c2a1513243ffd302809e5086fe736",
+            "language": "Hebrew",
+            "malId": 11970,
+            "name": "Mendelman, Ami"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+            "language": "English",
+            "malId": 253,
+            "name": "Sabat, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67963.jpg?s=a6379a67c1d9f40bdf6a4d2b72f7f8cc",
+            "language": "Portuguese (BR)",
+            "malId": 36892,
+            "name": "Caodaglio, Marcelo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/53213.jpg?s=b82983f5d6f8417bf3e309d121b64d5a",
+        "malId": 4850,
+        "name": "North Kaio",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/17749.jpg?s=e9d4a608a2404f760d98a9e09649b502",
+            "language": "Japanese",
+            "malId": 670,
+            "name": "Yanami, Jouji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/42833.jpg?s=4333bd5e0eeb42a25b312aec15072e4c",
+            "language": "English",
+            "malId": 1000,
+            "name": "Schemmel, Sean"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33099.jpg?s=593765acb092dfc83f74aec2bdf4cef6",
+            "language": "Japanese",
+            "malId": 1522,
+            "name": "Tatsuta, Naoki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42348.jpg?s=d790e8181b5715d0daef9e16ce8afd31",
+            "language": "Portuguese (BR)",
+            "malId": 40351,
+            "name": "Silveira, Carlos"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/46563.jpg?s=47bdbb1f0c9a58b999e75b0a99d2a529",
+            "language": "Italian",
+            "malId": 43064,
+            "name": "Rasini, Cesare"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/48990.jpg?s=933346e17ae0b9bc50bbae727781299f",
+            "language": "German",
+            "malId": 45540,
+            "name": "Eichel, Kaspar"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/70718.jpg?s=ffbed4cb58ddfa2c9a4b2dd85a4c02d1",
+            "language": "English",
+            "malId": 351,
+            "name": "McConnohie, Michael"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71219.jpg?s=493b5311ee8e001edc32fe35a5e3a220",
+            "language": "Spanish",
+            "malId": 60985,
+            "name": "Hill, Ricardo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/79394.jpg?s=79d121c03fba42617793f2c104808a1c",
+            "language": "French",
+            "malId": 24245,
+            "name": "Lévy, Gilbert"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/535971.jpg?s=fff02e158c18f9587ebe0f3116af3ccc",
+        "malId": 6106,
+        "name": "Mr. Popo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/30181.jpg?s=d5dd30d9e92386e9f8d26770b8ccb838",
+            "language": "French",
+            "malId": 1150,
+            "name": "Legrand, Eric"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/46526.jpg?s=74d791ee335b1607fb5ae132e4755445",
+            "language": "Italian",
+            "malId": 43037,
+            "name": "Galoforo, Graziano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/40450.jpg?s=4b23fe47027b3434eeae29c5f0b16c94",
+            "language": "Japanese",
+            "malId": 7713,
+            "name": "Kawazu, Yasuhiko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/62698.jpg?s=e8ab9a46e316550e5119b570f58fe574",
+            "language": "Portuguese (BR)",
+            "malId": 43640,
+            "name": "Marchetti, César"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67574.jpg?s=54f8a948ede37a0c09dc0ea675edc3dc",
+            "language": "Spanish",
+            "malId": 7098,
+            "name": "Segundo, Carlos"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/7/65049.jpg?s=93245f4ea44f894018c3446628fc7d9f",
+        "malId": 6127,
+        "name": "Shen Long",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "German",
+            "malId": 45572,
+            "name": "Kunze, Mathias"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/10127.jpg?s=50713fb59858af5a9668701332ee53b3",
+            "language": "Japanese",
+            "malId": 836,
+            "name": "Ootomo, Ryuuzaburou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63177.jpg?s=c9011887bc42c8637c9b0e250dfca064",
+            "language": "Portuguese (BR)",
+            "malId": 46044,
+            "name": "Mendes, Vanderlan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/66270.jpg?s=7f2c4efbe27db65667783e556f59ed52",
+            "language": "French",
+            "malId": 26393,
+            "name": "Nouel, Antoine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+            "language": "English",
+            "malId": 253,
+            "name": "Sabat, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/52187.jpg?s=a6c855c7791bab6389925214579e636e",
+            "language": "Spanish",
+            "malId": 52910,
+            "name": "Tomé, Jorge"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/102021.jpg?s=c059016ec2069e3d78f6be30454d863d",
+        "malId": 5499,
+        "name": "Tenshinhan",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/15961.jpg?s=bf1456503e17c34dd414d3e9478fde64",
+            "language": "English",
+            "malId": 251,
+            "name": "Burgmeier, John"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47194.jpg?s=fa0f6dee515ac01718c8197c32a8ef3d",
+            "language": "English",
+            "malId": 39799,
+            "name": "Chase, Ray"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/72227.jpg?s=ae88b806be8cdb25ebb81dcaa796fa3a",
+            "language": "Portuguese (BR)",
+            "malId": 11530,
+            "name": "Marconato, Alexandre"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1139.jpg?s=16c7fcfe5eab72b8dfc2b561c31e0b77",
+            "language": "Italian",
+            "malId": 1092,
+            "name": "Ridolfo, Claudio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/31853.jpg?s=d4fddc33c82d38a88b26f91a62bb1aa9",
+            "language": "Spanish",
+            "malId": 13305,
+            "name": "Larumbe, Ismael"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/32503.jpg?s=2e7d5323ea9db27f19ce747c1a728504",
+            "language": "German",
+            "malId": 31351,
+            "name": "Gerhardt, Sven"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/76155.jpg?s=9a30973e8b9a40a1fbd4d6cf0b20d790",
+            "language": "Japanese",
+            "malId": 112,
+            "name": "Midorikawa, Hikaru"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/307928.jpg?s=1749faa17e24c374f5f2b4d8f5302134",
+        "malId": 141140,
+        "name": "Zenou",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/16847.jpg?s=00798470c81f6192e8fd41f09c9f84a7",
+            "language": "German",
+            "malId": 15555,
+            "name": "Schmidt, Josephine"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/43351.jpg?s=969c4a77d07a13e7aa935e9d73c29f16",
+            "language": "English",
+            "malId": 33051,
+            "name": "Wiedenheft, Sarah"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/16291.jpg?s=b465ee4faeab2e18ab8205f6f3b064f8",
+            "language": "Japanese",
+            "malId": 470,
+            "name": "Koorogi, Satomi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46362.jpg?s=1ad9f09d268339d3fe1e5500c7eda6ed",
+            "language": "Italian",
+            "malId": 42903,
+            "name": "Bonfitto, Sabrina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70980.jpg?s=eb4ea171bca3742d01fd7063f72c68e0",
+            "language": "Spanish",
+            "malId": 57195,
+            "name": "González, Desireé"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67476.jpg?s=ff50105bede34513c44198b231e6e6b1",
+            "language": "French",
+            "malId": 1613,
+            "name": "Lecordier, Brigitte"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/75283.jpg?s=c0d6eb2cf256f863d329beb4b43ad502",
+            "language": "Portuguese (BR)",
+            "malId": 46008,
+            "name": "Zink, Ma"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/357384.jpg?s=5e809a63589de2b4cafc32470f464532",
+        "malId": 154830,
+        "name": "Geene",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "Italian",
+            "malId": 42944,
+            "name": "Bestoso, Vittorio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/5206.jpg?s=de32e0b014809123b6dabe194f60422b",
+            "language": "Japanese",
+            "malId": 6506,
+            "name": "Oda, Yuusei"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65720.jpg?s=4295ec2c25f697f9717caad22a299818",
+            "language": "French",
+            "malId": 55541,
+            "name": "Melennec, Patrice"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71221.jpg?s=ef8a14e07e35ceb41712c363e52f6a91",
+            "language": "Spanish",
+            "malId": 60983,
+            "name": "Gutiérrez Coto, Sergio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/86861.jpg?s=8639cc25746c78eda644daae0cb2704d",
+            "language": "English",
+            "malId": 60277,
+            "name": "Murdock, Reagan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69876.jpg?s=f184a4147aee4e1d681f62783e8a84bf",
+            "language": "Portuguese (BR)",
+            "malId": 44292,
+            "name": "Emílio, César"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/357643.jpg?s=042e6a6f32e66b683b397dae9e203d40",
+        "malId": 161813,
+        "name": "Comfrey",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/70947.jpg?s=d598e52907f4c134ed4fda4b5565bc23",
+            "language": "English",
+            "malId": 60528,
+            "name": "Mai, Alex"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/86309.jpg?s=5a323b8665bd862d208ef90f24cf9587",
+            "language": "Spanish",
+            "malId": 16673,
+            "name": "Campuzano, Manuel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/18159.jpg?s=3d7951b5c204e9befd0987e104267682",
+            "language": "Japanese",
+            "malId": 1675,
+            "name": "Tanaka, Ryouichi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/79735.jpg?s=f0c97a1d03a2439c1836e8cff75dbc73",
+            "language": "Portuguese (BR)",
+            "malId": 43670,
+            "name": "Gama, Lucas"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/357669.jpg?s=1575ef551a24a697aa161717aef075e5",
+        "malId": 161819,
+        "name": "Methiop",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/58135.jpg?s=f0d78d8dd28abf06272c9d95dc16a21c",
+            "language": "Japanese",
+            "malId": 440,
+            "name": "Kishio, Daisuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/47853.jpg?s=ce9b564855c5d1cb252c11fb05d988b4",
+            "language": "Spanish",
+            "malId": 13263,
+            "name": "Matus, Edson"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67794.jpg?s=4889f2a9d67fbbe7f350ebbad644e909",
+            "language": "French",
+            "malId": 18873,
+            "name": "Bozo, Philippe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67963.jpg?s=a6379a67c1d9f40bdf6a4d2b72f7f8cc",
+            "language": "Portuguese (BR)",
+            "malId": 36892,
+            "name": "Caodaglio, Marcelo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/357970.jpg?s=7a4b3cbde69f0cefa11f5181931e13ae",
+        "malId": 2107,
+        "name": "Bulma's Mother",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "German",
+            "malId": 46577,
+            "name": "Ringer, Angela"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/26915.jpg?s=0ea5349cc9527223f5c407c80903951e",
+            "language": "Japanese",
+            "malId": 8760,
+            "name": "Emori, Hiroko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/62399.jpg?s=f92cc1e39d7f0f3c29199e7bcb717182",
+            "language": "Portuguese (BR)",
+            "malId": 12095,
+            "name": "Lemes, Cecília"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/71210.jpg?s=83fdf7999c95b49faccdd908a425906f",
+            "language": "Spanish",
+            "malId": 61064,
+            "name": "Villanueva Vargas, Ángela"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/39428.jpg?s=4bb838a3e7e1f5633a873c40da869963",
+            "language": "English",
+            "malId": 851,
+            "name": "Cranz, Cynthia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/47451.jpg?s=763bba63a0d4270b75f3d11350c836ca",
+            "language": "Italian",
+            "malId": 43940,
+            "name": "Porta, Graziella"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67478.jpg?s=6bb457aaa9d4318c6d130d0daf0216ad",
+            "language": "French",
+            "malId": 30739,
+            "name": "Giraudon, Marie"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/358557.jpg?s=21c066f8761ea99566b7dbe54366911c",
+        "malId": 88229,
+        "name": "Teirimentenpibosshi, Jaco",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/87271.jpg?s=2d3e06826b8b8d676acd585efad3d8ef",
+            "language": "Italian",
+            "malId": 1286,
+            "name": "Di Benedetto, Massimo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/41150.jpg?s=acc6758e6d153a0351c227af22894b81",
+            "language": "German",
+            "malId": 40192,
+            "name": "Sierich, Bastian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/62395.jpg?s=ad00156ead74b7bbe740ceac875a59ba",
+            "language": "Portuguese (BR)",
+            "malId": 5141,
+            "name": "Kumode, Robson"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77173.jpg?s=b2cbd78bbaa33c44fc94abe68e2c1822",
+            "language": "Korean",
+            "malId": 68469,
+            "name": "Shim, Gyu-hyeok"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/78101.jpg?s=a9b90c35f3b44f46044c62bc9db3d7c6",
+            "language": "Spanish",
+            "malId": 21357,
+            "name": "Coronel, Bruno"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80545.jpg?s=44302bf60883d6c920404010cff73f55",
+            "language": "English",
+            "malId": 860,
+            "name": "Haberkorn, Todd"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71252.jpg?s=7a8455456d186cf2cce7119bd3d7c414",
+            "language": "French",
+            "malId": 9882,
+            "name": "Pascal, Benjamin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85088.jpg?s=5d92d9ced275bc155d2b350aeb9214f9",
+            "language": "Japanese",
+            "malId": 16635,
+            "name": "Hanae, Natsuki"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/359096.jpg?s=8697a87e8e53ff9cf7f491bd60951882",
+        "malId": 161816,
+        "name": "Lilibeu",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/57708.jpg?s=14507772a7d4efb4741e0fbd7eedfafd",
+            "language": "Japanese",
+            "malId": 77,
+            "name": "Asano, Masumi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69880.jpg?s=4fcb671dee443f2c43b0648e19d6e0e9",
+            "language": "Portuguese (BR)",
+            "malId": 1442,
+            "name": "Keplmair, Tatiane"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/49583.jpg?s=fc7e326c07a80e0ffb49aabbf9111402",
+            "language": "English",
+            "malId": 34555,
+            "name": "LaPorte, Krystal"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/359143.jpg?s=83a45a96beac6620666e2829766c479d",
+        "malId": 161770,
+        "name": "Cocotte",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/44905.jpg?s=9951235d6babb6c1c1ac9e6d4998316d",
+            "language": "French",
+            "malId": 24241,
+            "name": "Fauveau, Jennifer"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/42919.jpg?s=10a814ae39ec6e19e43a61a6ecc09521",
+            "language": "English",
+            "malId": 40577,
+            "name": "Lenti, Marissa"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63904.jpg?s=4018e7554b1535d2fd702398a231b1aa",
+            "language": "Japanese",
+            "malId": 130,
+            "name": "Yamaguchi, Yuriko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/68347.jpg?s=7f791c53751feb495ad717d771c07acc",
+            "language": "Portuguese (BR)",
+            "malId": 11834,
+            "name": "Concepcion, Priscilla"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69912.jpg?s=b5116c8b6e9007cf9d85b5c2b017a783",
+            "language": "Spanish",
+            "malId": 59213,
+            "name": "Madera, Cony"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1277.jpg?s=edc7875ae0e5501427efcf4f5c3d4cbe",
+            "language": "Italian",
+            "malId": 1284,
+            "name": "Granato, Jolanda"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/364679.jpg?s=b65da9d1d637f9314f171ca80114fb15",
+        "malId": 161804,
+        "name": "Pirina",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/41476.jpg?s=ef8e4e6825ee2eb5d5e647ef2de74c8d",
+            "language": "English",
+            "malId": 19285,
+            "name": "Greene, Jarrod"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67494.jpg?s=45a31cbddbeef723c8a3ce90d6041465",
+            "language": "French",
+            "malId": 56644,
+            "name": "Atlan, Jean-Luc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/72858.jpg?s=b3f1e037fe7e4c0af2eecc6aafceee6e",
+            "language": "Spanish",
+            "malId": 62365,
+            "name": "Solo, Raúl"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/88690.jpg?s=2a67ae7e8b96c19a88b83e9ef3e1c693",
+            "language": "Japanese",
+            "malId": 1481,
+            "name": "Egawa, Hisao"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/69876.jpg?s=f184a4147aee4e1d681f62783e8a84bf",
+            "language": "Portuguese (BR)",
+            "malId": 44292,
+            "name": "Emílio, César"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/380614.jpg?s=bb19168df22cfb476e7c475823500566",
+        "malId": 170672,
+        "name": "Kibitoshin",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/58138.jpg?s=1764883e10265cc0275fef6f7486c52d",
+            "language": "Japanese",
+            "malId": 1521,
+            "name": "Oota, Shinichirou"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/61900.jpg?s=e14d1173a4ab1b8d48fe3ce7c980f240",
+            "language": "Portuguese (BR)",
+            "malId": 7344,
+            "name": "Brêtas, Francisco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69785.jpg?s=831409b49d8042832e70d1b34194021a",
+            "language": "French",
+            "malId": 26645,
+            "name": "de Boüard, Vincent"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68394.jpg?s=021cbe07de790fe979d796677453cb41",
+            "language": "Spanish",
+            "malId": 57250,
+            "name": "Vásquez, Genaro"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/8/45628.jpg?s=7f3263916ca42434072fb20a7590c277",
+        "malId": 914,
+        "name": "Piccolo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/26697.jpg?s=1f04f6cdfab61dd5592d0254200f9122",
+            "language": "Italian",
+            "malId": 11922,
+            "name": "Olivero, Alberto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71098.jpg?s=a7b6faef444812a5c089d852e160ec8f",
+            "language": "Japanese",
+            "malId": 673,
+            "name": "Furukawa, Toshio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/83080.jpg?s=01f7b4f1cc8e32fa0744d7a53ee5fb1b",
+            "language": "Spanish",
+            "malId": 80468,
+            "name": "Ríos, Luis Fernando"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/9255.jpg?s=12e3fb35a012d56dd84f1388ed585f9b",
+            "language": "German",
+            "malId": 10700,
+            "name": "Spieß, Felix"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/37203.jpg?s=b177a385f138fc3499d5f3fe188dde3d",
+            "language": "Italian",
+            "malId": 35543,
+            "name": "Ghignone, Luca"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/44411.jpg?s=3d2a27b5b55f6aeb2688dd3cab1cf581",
+            "language": "French",
+            "malId": 39332,
+            "name": "Ariotti, Philippe"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47113.jpg?s=feae1bb33be3f2958c0f6a487dfcccff",
+            "language": "Portuguese (BR)",
+            "malId": 43723,
+            "name": "Loy, João"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47194.jpg?s=fa0f6dee515ac01718c8197c32a8ef3d",
+            "language": "English",
+            "malId": 39799,
+            "name": "Chase, Ray"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42874.jpg?s=aef91fd9132c86444be351f412b0cfeb",
+            "language": "English",
+            "malId": 253,
+            "name": "Sabat, Christopher"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/62687.jpg?s=b9e9f6bfb0e432ae68995779057165ea",
+            "language": "Portuguese (BR)",
+            "malId": 13319,
+            "name": "Lobue, Luiz Antônio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67574.jpg?s=54f8a948ede37a0c09dc0ea675edc3dc",
+            "language": "Spanish",
+            "malId": 7098,
+            "name": "Segundo, Carlos"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/144261.jpg?s=d84bac076b96642543237799aa18fe4b",
+        "malId": 18063,
+        "name": "Norimaki, Gajira",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/81602.jpg?s=85ac0c053c2b020b56bc0e3e27a241f1",
+            "language": "Portuguese (BR)",
+            "malId": 21185,
+            "name": "Paulita, Agatha"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33015.jpg?s=0dfa68bd85746d2b17f2787fab886eb5",
+            "language": "Japanese",
+            "malId": 10516,
+            "name": "Teppouzuka, Yoko"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/75911.jpg?s=62988d647cbf26186268365c6680046f",
+            "language": "Portuguese (BR)",
+            "malId": 43998,
+            "name": "de Brito, Giulia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/32999.jpg?s=bccf30e91d330b884f5781bbe5dfb4d2",
+            "language": "Japanese",
+            "malId": 725,
+            "name": "Nishihara, Kumiko"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/302746.jpg?s=2ab7b8570013bc90f5eb935e0b06e5f0",
+        "malId": 138964,
+        "name": "Zunoo",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/14647.jpg?s=4916e1f1470e879bb4a0bae428127313",
+            "language": "English",
+            "malId": 1553,
+            "name": "Penz, Daniel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/58139.jpg?s=2dd5785957903d865b3e85e120c78821",
+            "language": "Japanese",
+            "malId": 1302,
+            "name": "Sonobe, Keiichi"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67939.jpg?s=2cfa56f530b2723234779ed9af28134b",
+            "language": "Portuguese (BR)",
+            "malId": 14489,
+            "name": "Monteiro, Dado"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69785.jpg?s=831409b49d8042832e70d1b34194021a",
+            "language": "French",
+            "malId": 26645,
+            "name": "de Boüard, Vincent"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/9075.jpg?s=c24a4869af2b93e464cfd613734879f7",
+            "language": "Italian",
+            "malId": 10572,
+            "name": "Sandri, Luca"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/302850.jpg?s=d4b88b96a4101748e57a8a4e6da902c1",
+        "malId": 134359,
+        "name": "Champa",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68845.jpg?s=d588a172db91efdcd3f731899d24da0a",
+            "language": "Spanish",
+            "malId": 57481,
+            "name": "Soto, Martín"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/25227.jpg?s=c1333ed2d886c3283e7442c773ddcdec",
+            "language": "Italian",
+            "malId": 21931,
+            "name": "Zanotti, Matteo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/47518.jpg?s=a5c58b6744f0de662bae21fb67fbf77c",
+            "language": "English",
+            "malId": 650,
+            "name": "Liebrecht, Jason"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/67284.jpg?s=750179dce5528e8cce88b93f7957b05d",
+            "language": "Portuguese (BR)",
+            "malId": 46293,
+            "name": "Nannetti, Júnior"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/76707.jpg?s=2da7919323fc0d702649972c4d691645",
+            "language": "Italian",
+            "malId": 42951,
+            "name": "Brusamonti, Matteo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/11307.jpg?s=6c5463a53b0534febf17479ee970b065",
+            "language": "Hebrew",
+            "malId": 11997,
+            "name": "Yosefsberg, Yoram"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/24250.jpg?s=c692293faba36a68fa12aeab65ddbb95",
+            "language": "Japanese",
+            "malId": 399,
+            "name": "Iwata, Mitsuo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85386.jpg?s=64e9e78aa21e52d8e4e696faf728700b",
+            "language": "Spanish",
+            "malId": 85639,
+            "name": "Prieto, Paco"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/350232.jpg?s=fa14e7df59adc997f4913939bc62c403",
+        "malId": 156586,
+        "name": "Maki",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/20755.jpg?s=aefab28fb39533912372f6e6977f6bd2",
+            "language": "English",
+            "malId": 16643,
+            "name": "Yu, Apphia"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/44180.jpg?s=e1226bde532ec84de960d697e122581d",
+            "language": "Japanese",
+            "malId": 41200,
+            "name": "Minami, Wakana"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/69911.jpg?s=0fc536b1740fbe1a3a76bf21575fc2db",
+            "language": "Portuguese (BR)",
+            "malId": 43997,
+            "name": "Vidal, Sicília"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71299.jpg?s=799f4d3249ec390ef3c3117113095efd",
+            "language": "Spanish",
+            "malId": 56690,
+            "name": "Ugalde, Erika"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/357380.jpg?s=c6b3e34c3b2ea5fbd6b0e6ad7087e5b2",
+        "malId": 154834,
+        "name": "Campari",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/67468.jpg?s=0ad70b9965f42967bd2eed170074937b",
+            "language": "Portuguese (BR)",
+            "malId": 11604,
+            "name": "Bezerra, Ulisses"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/71268.jpg?s=405c21fe4d7ae302eab353f32540dbda",
+            "language": "French",
+            "malId": 26387,
+            "name": "Bretonnière, Marc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/84639.jpg?s=04305c76d8aff35b71219346e81f5587",
+            "language": "Portuguese (BR)",
+            "malId": 43822,
+            "name": "Cruz, Walter"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/87556.jpg?s=ef3a42b86931776c5311dfd05f2b9f26",
+            "language": "Japanese",
+            "malId": 651,
+            "name": "Shimada, Bin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/42495.jpg?s=464cb888a485224e64301f5965e95f14",
+            "language": "Portuguese (BR)",
+            "malId": 40374,
+            "name": "Vaccari, Hélio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/81180.jpg?s=effc27779b7c435ac91fc76e78e0e08f",
+            "language": "Spanish",
+            "malId": 76146,
+            "name": "Coria, Guillermo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/357644.jpg?s=d363c7d2d7d59d8854aa6c794e1cdbcc",
+        "malId": 161793,
+        "name": "Damon",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/73464.jpg?s=21d718b6a4fc1f97993e746e48d1445a",
+            "language": "Spanish",
+            "malId": 57807,
+            "name": "Muñoz, Eleazar"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/63177.jpg?s=c9011887bc42c8637c9b0e250dfca064",
+            "language": "Portuguese (BR)",
+            "malId": 46044,
+            "name": "Mendes, Vanderlan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/55048.jpg?s=f182d8cc9f5e25f9556cc4a3bc01b892",
+            "language": "Japanese",
+            "malId": 234,
+            "name": "Tanaka, Hideyuki"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/359005.jpg?s=a293a78447797dc3de02558ed76a78e5",
+        "malId": 161815,
+        "name": "Murichim",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65720.jpg?s=4295ec2c25f697f9717caad22a299818",
+            "language": "French",
+            "malId": 55541,
+            "name": "Melennec, Patrice"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68483.jpg?s=17f7f4f0400c0c70c94df31fd3b819fa",
+            "language": "Spanish",
+            "malId": 57215,
+            "name": "Llapur, Sebastian"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/86861.jpg?s=8639cc25746c78eda644daae0cb2704d",
+            "language": "English",
+            "malId": 60277,
+            "name": "Murdock, Reagan"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/46361.jpg?s=f37e3052086a12e7808c9f95fe17f17f",
+            "language": "Italian",
+            "malId": 42902,
+            "name": "Benedetti, Marco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/16329.jpg?s=f42618ef7b31c338c5a42a160ff3dc62",
+            "language": "Japanese",
+            "malId": 9945,
+            "name": "Hirai, Keiji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/77324.jpg?s=7cb24b19355ebfa289d06498f9711fb6",
+            "language": "Portuguese (BR)",
+            "malId": 43693,
+            "name": "Silva, Dláigelles"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/359027.jpg?s=946fc9a462e6f2f455f36f465f246d6a",
+        "malId": 153830,
+        "name": "Quitela",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/69785.jpg?s=831409b49d8042832e70d1b34194021a",
+            "language": "French",
+            "malId": 26645,
+            "name": "de Boüard, Vincent"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33097.jpg?s=66e8122478b63ad39225f1e669015277",
+            "language": "Japanese",
+            "malId": 7631,
+            "name": "Numata, Yusuke"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/80443.jpg?s=5a2181cde00d37e355bbf757b445d3ad",
+            "language": "Portuguese (BR)",
+            "malId": 43861,
+            "name": "Fagundes, Vinícius"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/38013.jpg?s=c0c9335f948e3e30697e4679d8aebc1f",
+            "language": "Italian",
+            "malId": 20242,
+            "name": "Pozzi, Stefano"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/58126.jpg?s=4695a16d5f250decf4da644727d841b9",
+            "language": "English",
+            "malId": 50422,
+            "name": "Grant, Meli"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68498.jpg?s=3de3b17beea5590b7f85969262cb0ed3",
+            "language": "Spanish",
+            "malId": 7094,
+            "name": "Garza, Eduardo"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/361030.jpg?s=bf997735c198ac87bb8734798f1e2512",
+        "malId": 163376,
+        "name": "Anat",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/23823.jpg?s=367d5b5ea58455617bc31dfdee4f2a55",
+            "language": "English",
+            "malId": 8060,
+            "name": "Burnett, Chris"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/5206.jpg?s=de32e0b014809123b6dabe194f60422b",
+            "language": "Japanese",
+            "malId": 6506,
+            "name": "Oda, Yuusei"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/70202.jpg?s=3fb1685bd961517e212691939aa0fb48",
+            "language": "Italian",
+            "malId": 57178,
+            "name": "Magni, Daniel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/78291.jpg?s=a7ec03120b4afe6610f702c0daddc8a6",
+            "language": "Spanish",
+            "malId": 21839,
+            "name": "Ruiz, Miguel Ángel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67557.jpg?s=d8c241f28c3e17b5aca077483b1bd4b8",
+            "language": "Portuguese (BR)",
+            "malId": 34839,
+            "name": "Di Fiori, Michel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/71252.jpg?s=7a8455456d186cf2cce7119bd3d7c414",
+            "language": "French",
+            "malId": 9882,
+            "name": "Pascal, Benjamin"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/77077.jpg?s=3f6b09de57095c4bdc79b99f9a8da2dd",
+            "language": "Portuguese (BR)",
+            "malId": 52954,
+            "name": "Novaes, Rodolfo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/85358.jpg?s=f57ecefc66da2b2ae81fa7e1ac0a339e",
+            "language": "Portuguese (BR)",
+            "malId": 52960,
+            "name": "Córdova, Thiago"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/364676.jpg?s=b14bce9faab50441b834913aed1bd0c4",
+        "malId": 163388,
+        "name": "Ill",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/37131.jpg?s=c23880d991ef893051b99c68153594b6",
+            "language": "Italian",
+            "malId": 9534,
+            "name": "Balzarotti, Marco"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/65561.jpg?s=f06a9cd2984bebc086b7fe35770daa3d",
+            "language": "Japanese",
+            "malId": 205,
+            "name": "Morita, Masakazu"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67235.jpg?s=fea908e2616dad8137bce32cc7a80a61",
+            "language": "Portuguese (BR)",
+            "malId": 21197,
+            "name": "Lima, Diego"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/69302.jpg?s=54cbe439835f94af880cdf1a5e4726a8",
+            "language": "Portuguese (BR)",
+            "malId": 5140,
+            "name": "Corsetti, Sérgio"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/72010.jpg?s=5deb8bf4f428638ef57c2ac3e45277b3",
+            "language": "French",
+            "malId": 55020,
+            "name": "Borg, Yoann"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/characters/9/380617.jpg?s=448cefaa910772dc34e257689ab3fd64",
+        "malId": 170676,
+        "name": "Gotenks",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/31099.jpg?s=908047e6ef472db61c22974cd9159db1",
+            "language": "Spanish",
+            "malId": 30599,
+            "name": "Willer, Gaby"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/70324.jpg?s=3f123300a3e33c79d4adc3c9e50cdeda",
+            "language": "Italian",
+            "malId": 42636,
+            "name": "Calatroni, Jacopo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/77340.jpg?s=2e78abe7d4d8d4fe06bc2e8bfb87fc0e",
+            "language": "Japanese",
+            "malId": 557,
+            "name": "Nozawa, Masako"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/27459.jpg?s=75949c01cc9ff34aef85f23a271bbab5",
+            "language": "Spanish",
+            "malId": 5682,
+            "name": "Torres, Laura"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/34225.jpg?s=a54556051335f6ca0f42df9f5f1108d9",
+            "language": "Portuguese (BR)",
+            "malId": 11518,
+            "name": "Noya, Fátima"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/63070.jpg?s=598b3356538e90461f293b56d18b0847",
+            "language": "Portuguese (BR)",
+            "malId": 45854,
+            "name": "Santana, Marina"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/67476.jpg?s=ff50105bede34513c44198b231e6e6b1",
+            "language": "French",
+            "malId": 1613,
+            "name": "Lecordier, Brigitte"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/73596.jpg?s=36ce828518bac787c697b2b471645fac",
+            "language": "Japanese",
+            "malId": 134,
+            "name": "Kusao, Takeshi"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 156761,
+        "name": "Singer",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/68842.jpg?s=a646dfc040c765b412a67ec2689812cf",
+            "language": "Spanish",
+            "malId": 57477,
+            "name": "Castillo, Beto"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/78882.jpg?s=c16fa5640200e56fc9cca3ab54ba8fc1",
+            "language": "Portuguese (BR)",
+            "malId": 52877,
+            "name": "Ebling, Gabriel"
+          }
+        ]
+      },
+      {
+        "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+        "malId": 40652,
+        "name": "Narrator",
+        "role": "Supporting",
+        "voiceActors": [
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/questionmark_23.gif?s=f7dcbc4a4603d18356d3dfef8abd655c",
+            "language": "German",
+            "malId": 45815,
+            "name": "Hemmo, Roland"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/17749.jpg?s=e9d4a608a2404f760d98a9e09649b502",
+            "language": "Japanese",
+            "malId": 670,
+            "name": "Yanami, Jouji"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/1/57689.jpg?s=f2570e54b37e3f3bc7ca69813c142288",
+            "language": "Portuguese (BR)",
+            "malId": 46628,
+            "name": "Vizarro, Ângelo"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/16519.jpg?s=b0e9471d0b0efe1c50737cc364343c44",
+            "language": "English",
+            "malId": 11979,
+            "name": "Morgan, Doc"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/2/33099.jpg?s=593765acb092dfc83f74aec2bdf4cef6",
+            "language": "Japanese",
+            "malId": 1522,
+            "name": "Tatsuta, Naoki"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/1240.jpg?s=5d4e9921ec240b87a0023b11054879ca",
+            "language": "Italian",
+            "malId": 1240,
+            "name": "Scarabelli, Mario"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/34701.jpg?s=4949e7a9a7b269fb394f6b75ee83ddda",
+            "language": "English",
+            "malId": 6457,
+            "name": "Vincent, David"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/52187.jpg?s=a6c855c7791bab6389925214579e636e",
+            "language": "Spanish",
+            "malId": 52910,
+            "name": "Tomé, Jorge"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/54811.jpg?s=1597ba44e5d6f7fd34c080f95be0de4a",
+            "language": "Spanish",
+            "malId": 62803,
+            "name": "Lavat, José"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/66401.jpg?s=57b60c21fe8100f8879198ce2cdc599a",
+            "language": "French",
+            "malId": 56069,
+            "name": "Ruhl, Michel"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/68902.jpg?s=bf867db63bcefebd06a12439aa2cfe16",
+            "language": "Spanish",
+            "malId": 57427,
+            "name": "Moya, Rubén"
+          },
+          {
+            "imageUrl": "https://cdn.myanimelist.net/images/voiceactors/3/9667.jpg?s=21e7cb855c3ff7eb49dc654889a8bed2",
+            "language": "Hungarian",
+            "malId": 10939,
+            "name": "Endrédi, Máté"
+          }
+        ]
+      }
+    ],
+    "createdAt": "2026-02-26T16:27:51.747Z",
+    "demographics": [
+      "Shounen"
+    ],
+    "duration": "23 min per ep",
+    "explicitGenres": [],
+    "external": [
+      "@DB_anime_info",
+      "ANN",
+      "AniDB",
+      "Official Site",
+      "Wikipedia"
+    ],
+    "genres": [
+      "Action",
+      "Adventure",
+      "Comedy",
+      "Fantasy"
+    ],
+    "id": "d3a744d5-1ce7-4d20-a9b2-fde229b685ca",
+    "imageUrl": "https://cdn.myanimelist.net/images/anime/7/74606.jpg",
+    "lastRefreshedAt": "2026-02-26T16:27:51.747Z",
+    "licensors": [
+      {
+        "malId": 102,
+        "name": "Funimation",
+        "type": "anime"
+      }
+    ],
+    "malId": 30694,
+    "numberOfEpisodes": 131,
+    "popularity": 222,
+    "producers": [
+      {
+        "malId": 127,
+        "name": "Yomiko Advertising",
+        "type": "anime"
+      },
+      {
+        "malId": 169,
+        "name": "Fuji TV",
+        "type": "anime"
+      }
+    ],
+    "rank": 2217,
+    "rating": "PG-13 - Teens 13 or older",
+    "relations": [
+      {
+        "entry": [
+          {
+            "malId": 14837,
+            "type": "anime"
+          },
+          {
+            "malId": 25389,
+            "type": "anime"
+          },
+          {
+            "malId": 63367,
+            "type": "anime"
+          }
+        ],
+        "relationType": "Alternative Version"
+      },
+      {
+        "entry": [
+          {
+            "malId": 2222,
+            "type": "anime"
+          },
+          {
+            "malId": 59832,
+            "type": "anime"
+          },
+          {
+            "malId": 59934,
+            "type": "anime"
+          }
+        ],
+        "relationType": "Character"
+      },
+      {
+        "entry": [
+          {
+            "malId": 22777,
+            "type": "anime"
+          },
+          {
+            "malId": 813,
+            "type": "anime"
+          }
+        ],
+        "relationType": "Parent Story"
+      },
+      {
+        "entry": [
+          {
+            "malId": 36946,
+            "type": "anime"
+          }
+        ],
+        "relationType": "Sequel"
+      },
+      {
+        "entry": [
+          {
+            "malId": 37885,
+            "type": "anime"
+          }
+        ],
+        "relationType": "Spin-Off"
+      },
+      {
+        "entry": [
+          {
+            "malId": 89734,
+            "type": "manga"
+          }
+        ],
+        "relationType": "Adaptation"
+      }
+    ],
+    "season": "summer",
+    "source": "Manga",
+    "status": "Finished Airing",
+    "studios": [
+      {
+        "malId": 18,
+        "name": "Toei Animation",
+        "type": "anime"
+      }
+    ],
+    "synopsis": "Seven years after the defeat of Majin Buu, Earth is at peace, and its people live free from any dangers lurking in the universe. However, this peace is short-lived; a sleeping threat awakens in the dark reaches of the galaxy: Beerus, the ruthless God of Destruction.\n\nDisturbed by a prophecy that he will be defeated by a \"Super Saiyan God,\" Beerus and his angelic attendant Whis search the universe for this mysterious being. Before long, they reach Earth and encounter Gokuu Son, one of the planet's mightiest warriors, and his powerful friends.\n\n[Written by MAL Rewrite]",
+    "theme": null,
+    "themes": [
+      "Martial Arts"
+    ],
+    "title": "Dragon Ball Super",
+    "titles": [
+      {
+        "title": "DB Super",
+        "type": "Synonym"
+      },
+      {
+        "title": "DBS",
+        "type": "Synonym"
+      },
+      {
+        "title": "Dragon Ball Chou",
+        "type": "Synonym"
+      },
+      {
+        "title": "Dragon Ball Super",
+        "type": "Default"
+      },
+      {
+        "title": "Dragon Ball Super",
+        "type": "English"
+      },
+      {
+        "title": "ドラゴンボール超（スーパー）",
+        "type": "Japanese"
+      }
+    ],
+    "trailer": {
+      "embedUrl": "https://www.youtube-nocookie.com/embed/ycaU9xEEdi8?enablejsapi=1&wmode=opaque&autoplay=1",
+      "url": null,
+      "youtubeId": null
+    },
+    "type": "TV",
+    "updatedAt": "2026-02-26T16:27:51.747Z",
+    "url": "https://myanimelist.net/anime/30694/Dragon_Ball_Super",
+    "videos": {
+      "episodes": [
+        {
+          "episode": "Episode 100",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/a01b634746ea4751753aa175612514501500771412_large.jpg",
+          "malId": 100,
+          "title": "Out Of Control! The Savage Berserker Awakens!!"
+        },
+        {
+          "episode": "Episode 101",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/17b6fae925d0c0571f622736abc8730a1501375727_large.jpg",
+          "malId": 101,
+          "title": "The Impending Warriors of Justice! The Pride Troopers!!"
+        },
+        {
+          "episode": "Episode 102",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/5ad752f8921d68a3347d76dbbe7f79bd1501981291_large.jpg",
+          "malId": 102,
+          "title": "The Power of Love Explodes?! Universe 2's Little Witch Warriors!!"
+        },
+        {
+          "episode": "Episode 103",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire3-tmb/ba00200d8003806d47a335f23bb014021502585238_large.jpg",
+          "malId": 103,
+          "title": "Gohan, Show No Mercy! Showdown With Universe 10!!"
+        },
+        {
+          "episode": "Episode 104",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/39b4486e1f4f55c3856ecdaef86076821503190331_large.jpg",
+          "malId": 104,
+          "title": "The Ultimate High Speed Battle Begins! Goku and Hit Join Forces!!"
+        },
+        {
+          "episode": "Episode 105",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire3-tmb/3b1e64088057031caac9aba614ae0c7b1503795107_large.jpg",
+          "malId": 105,
+          "title": "A Desperate Battle! Master Roshi's Sacrifice!!"
+        },
+        {
+          "episode": "Episode 106",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/46d2bdfa049ca18fb0c38155abbf52631504399947_large.jpg",
+          "malId": 106,
+          "title": "Find Him! Death Match With An Invisible Attacker!!"
+        },
+        {
+          "episode": "Episode 107",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/195446217649570a4616b86b2d5cecc31505609601_large.jpg",
+          "malId": 107,
+          "title": "Revenge \"F\" The Cunning Trap?!"
+        },
+        {
+          "episode": "Episode 108",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/50df86a4c7ad454f4e48d80db2526c151506214278_large.jpg",
+          "malId": 108,
+          "title": "Frieza and Frost! Conjoined Malice?!"
+        },
+        {
+          "episode": "Episode 109",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/fd7cc0747a6100af3270402b93a976481507428930_large.jpg",
+          "malId": 109,
+          "title": "The Ultimate Enemy Approaches Goku! Now, Let Loose! The Killer Spirit Bomb"
+        },
+        {
+          "episode": "Episode 110",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire4-tmb/faf7da7aa402815ad9a2082f0371b5261507428791_large.jpg",
+          "malId": 110,
+          "title": "Son Goku Wakes! New Level of the Awakened!!"
+        },
+        {
+          "episode": "Episode 111",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/82e75030285ad03f57dd321a0b0b2ab31508028169_large.jpg",
+          "malId": 111,
+          "title": "The Surreal Supreme Battle! Hit vs Jiren!!"
+        },
+        {
+          "episode": "Episode 112",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/389e7097f276b053b4b800ffb17abed81508633279_large.jpg",
+          "malId": 112,
+          "title": "A Saiyan's Vow! Vegeta's Resolution!!"
+        },
+        {
+          "episode": "Episode 113",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/932b3e53256f6c2b046a482d14e69d861509240299_large.jpg",
+          "malId": 113,
+          "title": "With Great Joy! The Repeat Battle-Crazy Saiyan Fight!!"
+        },
+        {
+          "episode": "Episode 114",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/81b8bebdc6fa28507a27500aa4cd82921509843145_large.jpg",
+          "malId": 114,
+          "title": "Intimidating Passion! The Birth of a New Super Warrior!!"
+        },
+        {
+          "episode": "Episode 115",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/79bf5d0816b04cae0b2e5db31d36c84f1510447721_large.jpg",
+          "malId": 115,
+          "title": "Goku VS Kefla! Super Saiyan Blue Defeated?!"
+        },
+        {
+          "episode": "Episode 116",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire3-tmb/c3b95f1d1cc4241dc1ebcb3eec9649201511052731_large.jpg",
+          "malId": 116,
+          "title": "The Sign of a Comeback! Ultra Instinct's Huge Explosion!!"
+        },
+        {
+          "episode": "Episode 117",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/ed2c70cd1cd2a98287a7937cd302ddee1511657068_large.jpg",
+          "malId": 117,
+          "title": "Showdown of Love! Androids VS Universe 2!!"
+        },
+        {
+          "episode": "Episode 118",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/195e23ef2443ea1adb49f89f4332dd461512261950_large.jpg",
+          "malId": 118,
+          "title": "Accelerated Tragedy - Vanishing Universes"
+        },
+        {
+          "episode": "Episode 119",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire3-tmb/e28c682651cf515f2e4f5cf7912983fb1512866960_large.jpg",
+          "malId": 119,
+          "title": "Unavoidable?! The Ferocity of a Stealth Attack!"
+        },
+        {
+          "episode": "Episode 120",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/1fbd0685638b12093056c987573a076f1513472254_large.jpg",
+          "malId": 120,
+          "title": "The Perfect Survival Tactic! Universe 3's Menacing Assassin!!"
+        },
+        {
+          "episode": "Episode 121",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire3-tmb/6493f738f3e325688852f4b34dcd4b0e1514076495_large.jpg",
+          "malId": 121,
+          "title": "All-Out War! The Ultimate Quadruple Merge vs Universe 7's Full-Scale Attack!!"
+        },
+        {
+          "episode": "Episode 122",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire4-tmb/0f516c561c86307c42141a63c338fb761515286550_large.jpg",
+          "malId": 122,
+          "title": "With His Pride on the Line! Vegeta's Challenge to Be the Strongest!!"
+        },
+        {
+          "episode": "Episode 123",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/cfa573811dca02d031262948e418f8f71515890754_large.jpg",
+          "malId": 123,
+          "title": "Body and Soul, Full Power Release! Goku and Vegeta!!"
+        },
+        {
+          "episode": "Episode 124",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire3-tmb/46937331b12f66c47f4dfcb49533de1c1516495579_large.jpg",
+          "malId": 124,
+          "title": "The Fiercely Overwhelming Assault! Gohan's Last Stand!!"
+        },
+        {
+          "episode": "Episode 125",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire4-tmb/1982ff5bc5be4b63fb644c786c87a2681517100225_large.jpg",
+          "malId": 125,
+          "title": "With Imposing Presence! God of Destruction Toppo Descends!!"
+        },
+        {
+          "episode": "Episode 126",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/577c9a9776b9cfdf3cdbac8758a2d1b01517705416_large.jpg",
+          "malId": 126,
+          "title": "Surpass Even A God! Vegeta's Desperate Blow!!"
+        },
+        {
+          "episode": "Episode 127",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/6d77f9afe61f0b0b2fe863b864b5d8831518309916_large.jpg",
+          "malId": 127,
+          "title": "The Approaching Wall! The Final Barrier Of Hope!!"
+        },
+        {
+          "episode": "Episode 128",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/782e52bd5958cf0436a5639f377907801518914939_large.jpg",
+          "malId": 128,
+          "title": "Noble Pride To The End! Vegeta Falls!!"
+        },
+        {
+          "episode": "Episode 129",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/01a7193a4c9b3dd78d08b60054252fc91520124335_large.jpg",
+          "malId": 129,
+          "title": "Limits Super Surpassed! Ultra Instinct Mastered!!"
+        },
+        {
+          "episode": "Episode 130",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire4-tmb/23bae74ef5e1a4b38ab76a54a86593bc1521333951_large.jpg",
+          "malId": 130,
+          "title": "The Greatest Showdown of all Time! The Ultimate Survival Battle!!"
+        },
+        {
+          "episode": "Episode 131",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/0bcaa34d54ffaaf92debcc5f84ad7d9a1521938730_large.jpg",
+          "malId": 131,
+          "title": "The Miraculous Conclusion! Farewell, Goku! Until We Meet Again!!"
+        },
+        {
+          "episode": "Episode 92",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire4-tmb/08509f78bd282e463e98fd498c1c75d81495932548_large.jpg",
+          "malId": 92,
+          "title": "Emergency Development! The Incomplete Ten Members!!"
+        },
+        {
+          "episode": "Episode 93",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire3-tmb/256a040c0f82f804851fd3e4cf2a6be41496537918_large.jpg",
+          "malId": 93,
+          "title": "You're The Tenth Warrior! Goku Goes To See Frieza!!"
+        },
+        {
+          "episode": "Episode 94",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire2-tmb/5e129c88bd38cb667afd0fc042f78cbb1497142098_large.jpg",
+          "malId": 94,
+          "title": "The Emperor of Evil Returns! A Reception of Mysterious Assassins?!"
+        },
+        {
+          "episode": "Episode 95",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire4-tmb/e1f8fdc7832cf78030978467c92719e21497746913_large.jpg",
+          "malId": 95,
+          "title": "The Worst! The Most evil! Frieza's Rampage!!"
+        },
+        {
+          "episode": "Episode 96",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/29d4a036475ccce8b870912ad7571c8d1498351664_large.jpg",
+          "malId": 96,
+          "title": "The Time Is Here! To The World Of Void For The Fate Of The Universe!!"
+        },
+        {
+          "episode": "Episode 97",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire3-tmb/31fd0d1e3ec914426135e4ac9693301d1498956131_large.jpg",
+          "malId": 97,
+          "title": "Survive! The Tournament of Power Begins at Last!!"
+        },
+        {
+          "episode": "Episode 98",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire3-tmb/28d4213a759b0802a31aff7344b282ad1499561264_large.jpg",
+          "malId": 98,
+          "title": "Oh, Uncertainty! A Universe Despairs!!"
+        },
+        {
+          "episode": "Episode 99",
+          "imageUrl": "https://img1.ak.crunchyroll.com/i/spire1-tmb/6162fc87abfbf3c1dd7f7fc5a2c5ecfb1500166181_large.jpg",
+          "malId": 99,
+          "title": "Show Them! Krillin's True Power!!"
+        }
+      ],
+      "musicVideos": [
+        {
+          "author": "Arukara",
+          "title": "\"Chaohan MUSIC (炒飯MUSIC)\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/xW8YZm9wPOY?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "Batten Shoujo-tai (ばってん少女隊)",
+          "title": "\"Yoka-Yoka Dance (よかよかダンス)\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/rBmy32Aq-9A?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "Czecho No Republic",
+          "title": "\"Forever Dreaming\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/9qw5ghJZgTs?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "Good Morning America",
+          "title": "\"Hello Hello Hello (ハローハローハロー)\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/Yvy47jU6DXc?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "KEYTALK",
+          "title": "\"Starring Star (スターリングスター)\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/OCaDLEsqRhY?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "Kazuya Yoshii (吉井和哉)",
+          "title": "\"Chouzetsu☆Dynamic! (超絶☆ダイナミック!)\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/uO5TYG4BBOk?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "Kiyoshi Hikawa (氷川きよし)",
+          "title": "\"Genkai Toppa × Survivor (限界突破×サバイバー)\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/S7QsHpLU1Sw?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "LACCO TOWER",
+          "title": "\"Haruka (遥)\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/ASyi5VzB9DQ?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "LACCO TOWER",
+          "title": "\"Usubeni (薄紅)\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/ZQkCktP8TS8?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "Miyu Inoue (井上実優)",
+          "title": "\"Boogie Back\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/gqNJvJdTcNI?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "ONEPIXCEL",
+          "title": "\"LAGRIMA\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/zzh-bM8gGiY?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "ROTTENGRAFFTY",
+          "title": "\"70cm Shiho no Madobe (70cm四方の窓辺)\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/z1K0XmvH8lk?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": "THE COLLECTORS",
+          "title": "\"Aku no Tenshi to Seigi no Akuma\"",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/I0hXq6vFPyU?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": null,
+          "title": null,
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/-1ahiGLoUM0?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": null,
+          "title": null,
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/HP2EYBxkea8?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": null,
+          "title": null,
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/Mh4LJq3kGs0?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "author": null,
+          "title": null,
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/pcr3fQLyCcM?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        }
+      ],
+      "promo": [
+        {
+          "title": "Teaser (FunimationNow Ver.)",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/ycaU9xEEdi8?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        },
+        {
+          "title": "Teaser FUNimation ver.",
+          "video": {
+            "embedUrl": "https://www.youtube-nocookie.com/embed/nZKs2Sbx4iM?enablejsapi=1&wmode=opaque&autoplay=1",
+            "url": null,
+            "youtubeId": null
+          }
+        }
+      ]
+    },
+    "year": 2015
+}]

--- a/src/routes/anime/index.tsx
+++ b/src/routes/anime/index.tsx
@@ -10,15 +10,15 @@ import {
 	CarouselNext,
 	CarouselPrevious,
 } from "@/components/ui/carousel.tsx";
-import gamesData from "@/lib/mockups/games.json";
+import animesData from "@/lib/mockups/animes.json";
 
-export const Route = createFileRoute("/game/")({
-	component: GameRoute,
+export const Route = createFileRoute("/anime/")({
+	component: animeRoute,
 });
 
-function GameRoute() {
+function animeRoute() {
 	const { t } = useTranslation();
-	const games = Array.isArray(gamesData) ? gamesData : [gamesData.game];
+	const animes = Array.isArray(animesData) ? animesData : [animesData.anime];
 
 	return (
 		<div className="mx-auto w-full">
@@ -30,47 +30,44 @@ function GameRoute() {
 				}}
 			>
 				<CarouselContent>
-					{games.map((game) => {
-						const artworks = Array.isArray(game.artworks) ? game.artworks : [];
-						const keyArt = artworks.find(
-							(a: any) => a.type === "Key art without logo",
-						)?.url;
-						const logoArt = artworks.find(
-							(a: any) => a.type === "Game logo (color)",
-						)?.url;
+					{animes.map((anime) => {
+						const getYoutubeThumbnail = (url: string) => {
+							if (!url) return null;
+							const match = url.match(/\/embed\/([^/?]+)/);
+							const videoId = match ? match[1] : null;
+							return videoId
+								? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
+								: null;
+						};
+
+						const trailerThumbnail = getYoutubeThumbnail(
+							anime.trailer?.embedUrl,
+						);
 
 						return (
-							<CarouselItem key={game.id}>
+							<CarouselItem key={anime.id}>
 								<div className="relative w-full overflow-hidden rounded-xl border border-border">
 									<img
-										src={keyArt || artworks[0]?.url || game.coverUrl}
-										className="w-full h-60 md:h-120 object-cover object-top"
-										alt={game.name}
+										src={trailerThumbnail || anime.imageUrl}
+										className="w-full h-60 md:h-120 object-cover"
+										alt={anime.title}
 									/>
 
 									<div className="absolute inset-0 bg-linear-to-t from-malachite-500/80 via-malachite-500/30 to-transparent" />
 
 									<div className="absolute inset-0 p-8 flex flex-col justify-end gap-4">
-										{logoArt ? (
-											<img
-												src={logoArt.replace(".jpg", ".png")}
-												className="h-24 object-contain self-start drop-shadow-lg"
-												alt={`${game.name} logo`}
-											/>
-										) : (
-											<h2 className="text-4xl font-bold drop-shadow-lg">
-												{game.name}
-											</h2>
-										)}
+										<h2 className="text-4xl font-bold drop-shadow-lg">
+											{anime.title}
+										</h2>
 
 										<div className="max-w-2xl hidden md:block">
 											<p className="text-lg line-clamp-2 text-white/90 drop-shadow-md">
-												{game.summary}
+												{anime.synopsis}
 											</p>
 										</div>
 
 										<Link
-											to={`/game/${game.id}`}
+											to={`/anime/${anime.id}`}
 											className="bg-primary text-primary-foreground w-fit px-6 py-2 rounded-full font-semibold hover:brightness-110 transition-all shadow-lg"
 										>
 											{t("common:viewDetails")}
@@ -92,38 +89,38 @@ function GameRoute() {
 			</Carousel>
 			<div className="py-6 space-y-4">
 				<div className="flex items-center justify-between mb-4">
-					<p className="text-2xl font-bold">{t("common:mostPopular")}</p>
+					<p className="text-2xl font-bold">{t("common:topAiring")}</p>
 					<Button>{t("pages:donate.viewAll")}</Button>
 				</div>
 				<Grid minColSize={"120px"} className={"grid-cols-5"}>
-					{games.map((game) => (
+					{animes.map((anime) => (
 						<CardItem
-							title={game.name}
-							url={`/game/${game.id}`}
-							imageURL={game.coverUrl}
-							rating={game.rating}
-							year={new Date(game.releaseDates[0].date).getFullYear()}
-							synopsis={game.summary}
-							mediaType={"game"}
-							key={game.id}
+							title={anime.title}
+							url={`/anime/${anime.id}`}
+							imageURL={anime.imageUrl}
+							rating={anime.rating}
+							year={anime.year}
+							synopsis={anime.background}
+							mediaType={"anime"}
+							key={anime.id}
 						/>
 					))}
 				</Grid>
 				<div className="flex items-center justify-between mb-4">
-					<p className="text-2xl font-bold">{t("common:recentlyReleased")}</p>
+					<p className="text-2xl font-bold">{t("common:recommendations")}</p>{" "}
 					<Button>{t("pages:donate.viewAll")}</Button>
 				</div>
 				<Grid minColSize={"120px"} className={"grid-cols-5"}>
-					{games.map((game) => (
+					{animes.map((anime) => (
 						<CardItem
-							title={game.name}
-							url={`/game/${game.id}`}
-							imageURL={game.coverUrl}
-							rating={game.rating}
-							year={new Date(game.releaseDates[0].date).getFullYear()}
-							synopsis={game.summary}
-							mediaType={"game"}
-							key={game.id}
+							title={anime.title}
+							url={`/anime/${anime.id}`}
+							imageURL={anime.imageUrl}
+							rating={anime.rating}
+							year={anime.year}
+							synopsis={anime.background}
+							mediaType={"anime"}
+							key={anime.id}
 						/>
 					))}
 				</Grid>
@@ -132,34 +129,34 @@ function GameRoute() {
 					<Button>{t("pages:donate.viewAll")}</Button>
 				</div>
 				<Grid minColSize={"120px"} className={"grid-cols-5"}>
-					{games.map((game) => (
+					{animes.map((anime) => (
 						<CardItem
-							title={game.name}
-							url={`/game/${game.id}`}
-							imageURL={game.coverUrl}
-							rating={game.rating}
-							year={new Date(game.releaseDates[0].date).getFullYear()}
-							synopsis={game.summary}
-							mediaType={"game"}
-							key={game.id}
+							title={anime.title}
+							url={`/anime/${anime.id}`}
+							imageURL={anime.imageUrl}
+							rating={anime.rating}
+							year={anime.year}
+							synopsis={anime.background}
+							mediaType={"anime"}
+							key={anime.id}
 						/>
 					))}
 				</Grid>
 				<div className="flex items-center justify-between mb-4">
-					<p className="text-2xl font-bold">{t("common:mostAnticipated")}</p>
+					<p className="text-2xl font-bold">{t("common:topAnime")}</p>
 					<Button>{t("pages:donate.viewAll")}</Button>
 				</div>
 				<Grid minColSize={"120px"} className={"grid-cols-5"}>
-					{games.map((game) => (
+					{animes.map((anime) => (
 						<CardItem
-							title={game.name}
-							url={`/game/${game.id}`}
-							imageURL={game.coverUrl}
-							rating={game.rating}
-							year={new Date(game.releaseDates[0].date).getFullYear()}
-							synopsis={game.summary}
-							mediaType={"game"}
-							key={game.id}
+							title={anime.title}
+							url={`/anime/${anime.id}`}
+							imageURL={anime.imageUrl}
+							rating={anime.rating}
+							year={anime.year}
+							synopsis={anime.background}
+							mediaType={"anime"}
+							key={anime.id}
 						/>
 					))}
 				</Grid>

--- a/src/routes/anime/index.tsx
+++ b/src/routes/anime/index.tsx
@@ -13,10 +13,10 @@ import {
 import animesData from "@/lib/mockups/animes.json";
 
 export const Route = createFileRoute("/anime/")({
-	component: animeRoute,
+	component: AnimeRoute,
 });
 
-function animeRoute() {
+function AnimeRoute() {
 	const { t } = useTranslation();
 	const animes = Array.isArray(animesData) ? animesData : [animesData.anime];
 


### PR DESCRIPTION
## Description
Implemented the `/anime` route displaying a carousel and grid for top anime, airing shows, and recommendations using mock data. Updated translations with new keys and improved header buttons for added functionality. Enhanced layout consistency with the existing `/game` route.

## Acknowledgements
- [x] I read the [PR Guidelines](https://github.com/TrackGeek/web/blob/main/.github/CONTRIBUTING.md)
- [x] I linted and formatted the code by running `npm run check`
- [x] The PR title follows the repo's [commit conventions](https://github.com/TrackGeek/web/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    At least TWO screenshots of the feature
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New anime page with hero carousel and curated sections: top airing, recommendations, coming soon, and top anime.
  * "View All" buttons added to game page section headers for easier navigation.

* **Localization**
  * Added translations: "Top Anime", "Top Airing", and "Recommendations".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->