### PR TITLE
feat(series): add `/series` route with detailed mock data

### DIFF
--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -169,7 +169,7 @@ export function Header() {
 							</Link>
 						</DropdownMenuItem>
 						<DropdownMenuItem asChild>
-							<Link to="/" className="cursor-pointer">
+							<Link to="/tv" className="cursor-pointer">
 								<TvMinimalPlay size={18} className="text-white" />
 								{t("common:types.tv_other")}
 							</Link>

--- a/src/lib/i18n/locales/en-US/common.json
+++ b/src/lib/i18n/locales/en-US/common.json
@@ -96,5 +96,6 @@
 	"topAnime": "Top Anime",
 	"topAiring": "Top Airing",
 	"recommendations": "Recommendations",
-	"topManga": "Top Manga"
+	"topManga": "Top Manga",
+	"trending": "Trending"
 }

--- a/src/lib/mockups/series.json
+++ b/src/lib/mockups/series.json
@@ -1,0 +1,954 @@
+[
+	{
+		"cast": [
+			{
+				"character": "Jane Doe",
+				"id": 59817,
+				"name": "Jaimie Alexander",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/21IQHPAXNUHiqPrpIYr4X8h2wmf.jpg"
+			},
+			{
+				"character": "Kurt Weller",
+				"id": 38664,
+				"name": "Sullivan Stapleton",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/vWadhfczxktoYQBC6TaAk6bE6Ci.jpg"
+			},
+			{
+				"character": "Patterson",
+				"id": 34486,
+				"name": "Ashley Johnson",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/8s36QwB7Zq3PrbY1W6a6ctTFFoe.jpg"
+			},
+			{
+				"character": "Rich Dotcom",
+				"id": 101251,
+				"name": "Ennis Esmer",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/1hMc79NC8bqJ5OWxLU2d2dlnrBr.jpg"
+			},
+			{
+				"character": "Tasha Zapata",
+				"id": 1152259,
+				"name": "Audrey Esparza",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/a0GKyMC2TncZR4Dvw1kmiEErlot.jpg"
+			}
+		],
+		"createdAt": "2026-02-27T16:42:46.911Z",
+		"createdBy": [
+			{
+				"id": 72101,
+				"name": "Martin Gero",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/83cTNfJtBcc1CGZCH1jQaNcDFDN.jpg"
+			}
+		],
+		"crew": [
+			{
+				"id": 1225841,
+				"job": "Executive Producer",
+				"name": "Christina M. Kim",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/y2fHLujHqv8pF4F4uDeCXHNtQn8.jpg"
+			},
+			{
+				"id": 1395152,
+				"job": "Executive Producer",
+				"name": "Sarah Schechter",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/8UgL2O24cC8SniiryeYmZuafU4G.jpg"
+			},
+			{
+				"id": 1486893,
+				"job": "Executive Producer",
+				"name": "Alex Berger",
+				"profileUrl": null
+			},
+			{
+				"id": 1512010,
+				"job": "Producer",
+				"name": "Carl Ogawa",
+				"profileUrl": null
+			},
+			{
+				"id": 1512011,
+				"job": "Producer",
+				"name": "Jennifer Lence",
+				"profileUrl": null
+			},
+			{
+				"id": 1515474,
+				"job": "Executive Producer",
+				"name": "Chris Pozzebon",
+				"profileUrl": null
+			},
+			{
+				"id": 1539828,
+				"job": "Co-Executive Producer",
+				"name": "Ryan Johnson",
+				"profileUrl": null
+			},
+			{
+				"id": 1539829,
+				"job": "Co-Executive Producer",
+				"name": "Peter Lalayanis",
+				"profileUrl": null
+			},
+			{
+				"id": 1676813,
+				"job": "Producer",
+				"name": "Sarah Rath",
+				"profileUrl": null
+			},
+			{
+				"id": 1676923,
+				"job": "Co-Executive Producer",
+				"name": "Rachel Caris Love",
+				"profileUrl": null
+			},
+			{
+				"id": 1683841,
+				"job": "Co-Executive Producer",
+				"name": "Chad McQuay",
+				"profileUrl": null
+			},
+			{
+				"id": 1716162,
+				"job": "Original Music Composer",
+				"name": "Sherri Chung",
+				"profileUrl": null
+			},
+			{
+				"id": 2683663,
+				"job": "Associate Producer",
+				"name": "Mike Ganzman",
+				"profileUrl": null
+			},
+			{
+				"id": 449223,
+				"job": "Executive Producer",
+				"name": "Brendan Gall",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/qBqoJLTtl6ANR8hUZ2FetSqjFLP.jpg"
+			},
+			{
+				"id": 53017,
+				"job": "Original Music Composer",
+				"name": "Blake Neely",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/ip0bUF22rBJNqLu5hTPEtzZa6hp.jpg"
+			},
+			{
+				"id": 72101,
+				"job": "Executive Producer",
+				"name": "Martin Gero",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/83cTNfJtBcc1CGZCH1jQaNcDFDN.jpg"
+			},
+			{
+				"id": 88967,
+				"job": "Executive Producer",
+				"name": "Greg Berlanti",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/1T24SiIIDMa9gAmq7QaYwZywq4y.jpg"
+			}
+		],
+		"episodeRuntime": [43],
+		"firstAirDate": "2015-09-21T00:00:00.000Z",
+		"genres": ["Action & Adventure", "Crime", "Drama"],
+		"homepage": "http://www.nbc.com/blindspot",
+		"id": "8f1be700-6346-457c-a65f-85cfa2a2e22f",
+		"inProduction": false,
+		"languages": ["en"],
+		"lastAirDate": "2020-07-23T00:00:00.000Z",
+		"lastEpisodeToAir": {
+			"airDate": "2020-07-23T00:00:00.000Z",
+			"episodeNumber": 11,
+			"id": 2313494,
+			"name": "Iunne Ennui",
+			"overview": "Turn off your mind, relax and float down stream...it is not dying...it is not dying.",
+			"seasonNumber": 5,
+			"stillUrl": "https://image.tmdb.org/t/p/w500/dJ8pjCmUVSEOR6ilEABSKbi16KT.jpg"
+		},
+		"lastRefreshedAt": "2026-02-27T16:42:46.911Z",
+		"name": "Blindspot",
+		"networks": [
+			{
+				"id": 6,
+				"logoUrl": "https://image.tmdb.org/t/p/w500/cm111bsDVlYaC1foL0itvEI4yLG.png",
+				"name": "NBC",
+				"originCountry": "US"
+			}
+		],
+		"nextEpisodeToAir": null,
+		"numberOfEpisodes": 100,
+		"numberOfSeasons": 5,
+		"originalLanguage": "en",
+		"originalName": "Blindspot",
+		"originCountry": ["US"],
+		"popularity": 32,
+		"posterUrl": "https://image.tmdb.org/t/p/w500/4AeYzamQmd9Fa6hawDmYKbdvBSe.jpg",
+		"productionCompanies": [
+			{
+				"logoUrl": "https://image.tmdb.org/t/p/w500/3e294jszfE6cE8TOogmj0zNd6pL.png",
+				"name": "Berlanti Productions",
+				"originCountry": "US"
+			},
+			{
+				"logoUrl": "https://image.tmdb.org/t/p/w500/pJJw98MtNFC9cHn3o15G7vaUnnX.png",
+				"name": "Warner Bros. Television",
+				"originCountry": "US"
+			},
+			{
+				"logoUrl": null,
+				"name": "Quinn's House",
+				"originCountry": "US"
+			}
+		],
+		"productionCountries": ["United States of America"],
+		"seasons": [
+			{
+				"airDate": "2015-09-21T00:00:00.000Z",
+				"episodes": [
+					{
+						"airDate": "2015-09-21T00:00:00.000Z",
+						"episodeNumber": 1,
+						"name": "Woe Has Joined",
+						"overview": "A beautiful, naked amnesiac is found in Times Square covered in mysterious tattoos, including one bearing the name of FBI Agent Kurt Weller. Special Agent Weller and his FBI team must decode the map of clues on Jane Doe's body in order to thwart a deadly terrorist attack. Who is Jane Doe - is she an asset or enemy? Who wiped her memory? And who is behind the tattoos?",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/62C0OKw0TM0NmnM4PINL7n0IgpW.jpg"
+					},
+					{
+						"airDate": "2015-09-28T00:00:00.000Z",
+						"episodeNumber": 2,
+						"name": "A Stray Howl",
+						"overview": "The team unlocks a cryptic tattoo that points to Major Arthur Gibson, an Air Force pilot with a painful past and a lethal agenda. Jane continues to search for clues to her identity and is haunted when flashes of a disturbing memory force her to question her past. Meanwhile, Weller thinks he might know Jane's true identity.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/9yLGK5rZ9tuDq0WVtUx6MCvnvVt.jpg"
+					},
+					{
+						"airDate": "2015-10-05T00:00:00.000Z",
+						"episodeNumber": 3,
+						"name": "Eight Slim Grins",
+						"overview": "An infamous crew of thieves almost pulls off the perfect jewel heist, except one thief - with a Navy SEAL tattoo identical to Jane's - is captured at the scene of the crime. Does this man know Jane? Meanwhile, Jane receives a visit - and an ambiguous warning - from the mysterious bearded man from her first memory as Weller and Mayfair struggle with Jane's role on the team.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/1qmrETyhIar6G02N756LTp4r4ab.jpg"
+					},
+					{
+						"airDate": "2015-10-12T00:00:00.000Z",
+						"episodeNumber": 4,
+						"name": "Bone May Rot",
+						"overview": "Patterson and her puzzle-expert boyfriend, David, decode a tattoo clue that sends the team to the Centers for Disease Control (CDC). While at the CDC, the team discovers a hidden message on Jane's body that uncovers a plot that could have catastrophic global consequences. Meanwhile, Jane and Weller grow closer.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/acLGSz6u0gK5Jr6xcfIqrR52wGN.jpg"
+					},
+					{
+						"airDate": "2015-10-19T00:00:00.000Z",
+						"episodeNumber": 5,
+						"name": "Split the Law",
+						"overview": "After a seemingly straightforward hostage situation turns out to have deeper international implications, the CIA and FBI find themselves racing against each other to apprehend the same criminal with a dark history. Carter expresses concern about Jane's trustworthiness, causing friction with Mayfair and testing Reade's loyalty to the team. Meeting Weller's family proves overwhelming for Jane as she grapples with her identity.\n\n",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/yfcvlOOtIuRO0N3fRJAFGdsYKHb.jpg"
+					},
+					{
+						"airDate": "2015-10-26T00:00:00.000Z",
+						"episodeNumber": 6,
+						"name": "Cede Your Soul",
+						"overview": "When an assassination leads the team to a dangerous app that allows criminals to track government vehicles, they have to work with the app's surprising creator to take it down. Jane and Weller attempt to keep their relationship professional. Zapata struggles with a moral issue.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/vFLMq3eKVCdyvqHrohl4ASvkTNO.jpg"
+					},
+					{
+						"airDate": "2015-11-02T00:00:00.000Z",
+						"episodeNumber": 7,
+						"name": "Sent On Tour",
+						"overview": "One of Jane's tattoos sends the team to a remote location where they find themselves face to face with a dangerous criminal in a case that puts Jane and Weller's strained relationship to the test and threatens to expose Mayfair's secrets. Meanwhile, Patterson breaks the rules to solve a tattoo puzzle.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/awJrjA29YUFaSnonZxXacWoR1Lw.jpg"
+					},
+					{
+						"airDate": "2015-11-09T00:00:00.000Z",
+						"episodeNumber": 8,
+						"name": "Persecute Envoys",
+						"overview": "After a police officer is murdered, Patterson unlocks a disturbing tattoo that appears to have predicted his killing, and the team chases a violent clue trail to stop further attacks. Mayfair reveals secrets from her past to Weller, seriously testing their relationship.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/ejWNe5EKxBAkJhehz9IEUf2idhk.jpg"
+					},
+					{
+						"airDate": "2015-11-16T00:00:00.000Z",
+						"episodeNumber": 9,
+						"name": "Authentic Flirt",
+						"overview": "Jane and Weller go undercover as a world-class assassin couple to prevent deadly information from getting into the wrong hands. The intimate assignment draws them closer than ever. Meanwhile, David embarks on a solo mission to win Patterson back, and Carter clashes with Mayfair over how to handle a dangerous individual.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/huvaMNi4REpcq5dRdqv6PWzCBLN.jpg"
+					},
+					{
+						"airDate": "2015-11-23T00:00:00.000Z",
+						"episodeNumber": 10,
+						"name": "Evil Handmade Instrument",
+						"overview": "In the thrilling mid-season finale the team goes after a group of sleeper spies that have just been activated and race to stop a slew of assassinations.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/yRBAn7ydYORDxa1vkkGhZRK53Da.jpg"
+					},
+					{
+						"airDate": "2016-02-29T00:00:00.000Z",
+						"episodeNumber": 11,
+						"name": "Cease Forcing Enemy",
+						"overview": "Jane reels from a series of massive revelations about her tattoos and grapples with whether to trust Oscar. Meanwhile, a tattoo leads the team to a shocking discovery in the Black Sea.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/e2g8colAWmKsN83kn6Xzly0tIb8.jpg"
+					},
+					{
+						"airDate": "2016-03-07T00:00:00.000Z",
+						"episodeNumber": 12,
+						"name": "Scientists Hollow Fortune",
+						"overview": "After a disturbed Iraq War vet shoots up a military base, the team exposes a sinister plot. As Jane and Weller race to stop a single-minded scientist, Jane recalls her own mysterious military past and contemplates a new relationship with Oscar.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/53DsiPQCaAYD63r4g9XUjl3aV5P.jpg"
+					},
+					{
+						"airDate": "2016-03-14T00:00:00.000Z",
+						"episodeNumber": 13,
+						"name": "Erase Weary Youth",
+						"overview": "After a tip reveals there's a mole within the FBI's New York Office, the team must hunt for the operative while facing extreme scrutiny from Inspector Fischer. The team's deepest secrets threaten to be exposed, and everyone is a potential suspect - but some, especially Jane Doe have more to hide.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/zjDwJivJbZ4aJT362hajAT6OMbu.jpg"
+					},
+					{
+						"airDate": "2016-03-21T00:00:00.000Z",
+						"episodeNumber": 14,
+						"name": "Rules in Defiance",
+						"overview": "An anonymous tip leads the team to investigate an urgent death row case,  ultimately sending Zapata undercover. After nearly  getting caught during the mole hunt, Jane considers  leaving the FBI.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/ubv0i5NgNAqwbV1fC6YH32Li5Oj.jpg"
+					},
+					{
+						"airDate": "2016-03-28T00:00:00.000Z",
+						"episodeNumber": 15,
+						"name": "Older Cutthroat Canyon",
+						"overview": "After a painting featuring one of Jane's tattoos is heisted from a gallery, the team discovers Jane is the real target. In order to protect her team, Jane goes AWOL.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/8KCa2FEbCLF7ACgntFeVOPkZhQu.jpg"
+					},
+					{
+						"airDate": "2016-04-04T00:00:00.000Z",
+						"episodeNumber": 16,
+						"name": "Any Wounded Thief",
+						"overview": "After an armored truck is robbed, the team discovers that the stolen goods are chemical weapons and they must race to thwart a terrorist plot. Meanwhile, Jane  grapples with a confusing memory of Weller - while growing even closer to Oscar. Meanwhile Patterson receives a phone call from someone from her past.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/wmL1827kROKJ64SNurWiwllRJiQ.jpg"
+					},
+					{
+						"airDate": "2016-04-11T00:00:00.000Z",
+						"episodeNumber": 17,
+						"name": "Mans Telepathic Loyal Lookouts",
+						"overview": "After Patterson discovers a hidden message in the New York Times crossword, she embarks on a tattoo scavenger hunt that leads her into danger. Oscar finally tells Jane more about who she was, and Weller seeks his Dad's opinion about who kidnapped Taylor Shaw.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/mzRrU9slA51BXLVavpbeZCsVh19.jpg"
+					},
+					{
+						"airDate": "2016-04-18T00:00:00.000Z",
+						"episodeNumber": 18,
+						"name": "One Begets Technique",
+						"overview": "In order to capture a dangerous international criminal, Jane and Weller are forced to collaborate with the only person he will meet: their former target, Rich DotCom. Jane must decide whether to risk hurting Weller by executing a morally questionable order from Oscar.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/fdfr9L31U53q1MORSyppkQIdWIm.jpg"
+					},
+					{
+						"airDate": "2016-04-25T00:00:00.000Z",
+						"episodeNumber": 19,
+						"name": "In the Comet of Us",
+						"overview": "When a school shooting breaks out during the investigation of a tattoo, the team splits up to take down the shooter. Mayfair copes with some issues from her past.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/7HeuWyBxU2bRq8Dtmu0Akc2ZRef.jpg"
+					},
+					{
+						"airDate": "2016-05-02T00:00:00.000Z",
+						"episodeNumber": 20,
+						"name": "Swift Hardhearted Stone",
+						"overview": "When a mysterious young girl with a tattoo connection falls into Borden's care, he brings her case to the FBI team -- but her ties to a terrorist organization prove dangerous for all of them. Meanwhile, a conflicted Jane starts to grow close to Weller again, and friendship blossoms between Borden and Patterson.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/8iLTVCcqcOV4cm2whS4aiLqV9C7.jpg"
+					},
+					{
+						"airDate": "2016-05-09T00:00:00.000Z",
+						"episodeNumber": 21,
+						"name": "Of Whose Uneasy Route",
+						"overview": "The FBI is locked down when criminal hackers infiltrate the building, trapping the team inside SIOC. As they fight their way out, the close quarters force Mayfair, Zapata, Reade, and Sarah to confront personal conflicts.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/bcexU20y6h0fXwIw1rjw0AM0Ofr.jpg"
+					},
+					{
+						"airDate": "2016-05-16T00:00:00.000Z",
+						"episodeNumber": 22,
+						"name": "If Love a Rebel, Death Will Render",
+						"overview": "After an abandoned baby is found with a tattoo identical to one of Jane's, the team races to piece together the child's identity and save dozens of infants. A furious Jane confronts Oscar about the outcome of his secret missions.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/j14mjbw253VdoPFh2i1SXpsv0qm.jpg"
+					},
+					{
+						"airDate": "2016-05-23T00:00:00.000Z",
+						"episodeNumber": 23,
+						"name": "Why Await Life's End",
+						"overview": "Weller searches for the truth within a heartbreaking and confounding assertion. Jane reaches out to a former suspect for help with Oscar. Meanwhile, the rest of the team struggles to help a friend...",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/yTYazr8EtYaFYe6BG1LzRuWVEBS.jpg"
+					}
+				],
+				"id": 66860,
+				"name": "Season 1",
+				"posterUrl": "https://image.tmdb.org/t/p/w500/kRXprdbfFs6FJYH3GAPrKYXQdQT.jpg",
+				"seasonNumber": 1
+			},
+			{
+				"airDate": "2016-09-14T00:00:00.000Z",
+				"episodes": [
+					{
+						"airDate": "2016-09-14T00:00:00.000Z",
+						"episodeNumber": 1,
+						"name": "In Night So Ransomed Rogue",
+						"overview": "After escaping from CIA custody, the team recaptures Jane and convinces her to become a triple-agent within her old  terrorist organization where she unlocks some major secrets from her  past, while recent betrayals from both sides threaten to tear her and  the team apart for good.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/CblfYpLWqI17ThycyaEdf9PXHn.jpg"
+					},
+					{
+						"airDate": "2016-09-21T00:00:00.000Z",
+						"episodeNumber": 2,
+						"name": "Heave Fiery Knot",
+						"overview": "The team races to stop a corrupt DEA agent from selling stinger missiles  to a drug cartel as Weller fights to keep everyone  together under the increasing pressures of Jane's rift with the others and the uncomfortable addition of Nas as co-leader.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/2q4ucr7iAYw4gUKiVkQQtWhesst.jpg"
+					},
+					{
+						"airDate": "2016-09-28T00:00:00.000Z",
+						"episodeNumber": 3,
+						"name": "Hero Fears Imminent Rot",
+						"overview": "Weller and the team must race the clock to stop a  series of escalating New York City bombings, while Jane is forced to go on an assassination mission to prove her  loyalty... or suffer the consequences.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/9WSf1BKbp0vyndPxPEJgKsQR0lh.jpg"
+					},
+					{
+						"airDate": "2016-10-05T00:00:00.000Z",
+						"episodeNumber": 4,
+						"name": "If Beth",
+						"overview": "Nas and Weller navigate their new dynamic as co-leaders during the team's hunt for a museum gala assassin, who turns out turns out to be harboring a dark secret. Jane starts to see a softer side of her old organization.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/96T3ekDVtopcBWOxUYHNd6gVkRX.jpg"
+					},
+					{
+						"airDate": "2016-10-12T00:00:00.000Z",
+						"episodeNumber": 5,
+						"name": "Condone Untidiest Thefts",
+						"overview": "After a prominent politician is almost killed during a rally, Weller and the team must work with U.S. Marshal Allie Knight to take down a mob leader.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/frYmLOzJynbiIOwoe4484d086qp.jpg"
+					},
+					{
+						"airDate": "2016-10-19T00:00:00.000Z",
+						"episodeNumber": 6,
+						"name": "Her Spy's Harmed",
+						"overview": "While Weller and Nas chase a fugitive whistleblower in Bulgaria, Jane goes on a Sandstorm mission with Roman. Reade and Zapata must deal with an urgent matter.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/lk0FmbBteOVigH5oTKNlqcjOnSY.jpg"
+					},
+					{
+						"airDate": "2016-10-26T00:00:00.000Z",
+						"episodeNumber": 7,
+						"name": "Resolves Eleven Myths",
+						"overview": "Rich Dotcom returns to the FBI when he needs help with a pressing issue.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/wZVba5X0wN0iniO7KGADd3xKGUd.jpg"
+					},
+					{
+						"airDate": "2016-11-09T00:00:00.000Z",
+						"episodeNumber": 8,
+						"name": "We Fight Deaths on Thick Lone Waters",
+						"overview": "When Weller and Jane go missing during an undercover operation, the rest of the team must interrogate two criminals who hold the key to finding them. AUSA Weitz returns with a vendetta against the team.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/llLNWU3e2Weakt9egTdzFCyvoiC.jpg"
+					},
+					{
+						"airDate": "2016-11-16T00:00:00.000Z",
+						"episodeNumber": 9,
+						"name": "Why Let Cooler Pasture Deform",
+						"overview": "After Jane discovers that Sandstorm is gearing up for an imminent attack, she risks everything to send a secret SOS to her FBI team.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/iIJDhqFREFr3YCuIrsRZvKoB6gM.jpg"
+					},
+					{
+						"airDate": "2017-01-04T00:00:00.000Z",
+						"episodeNumber": 10,
+						"name": "Nor I, Nigel, AKA Leg in Iron",
+						"overview": "Patterson is missing... and a newly amnesiac Roman is on the loose. Jane and Weller must race Shepherd – and the clock – to find them before it's too late.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/bCTU1IrKYmW7BBhMGkvw5DHpQgM.jpg"
+					},
+					{
+						"airDate": "2017-01-11T00:00:00.000Z",
+						"episodeNumber": 11,
+						"name": "Droll Autumn, Unmutual Lord",
+						"overview": "After one of the world's most-wanted terrorists surfaces in New York for unknown reasons, the team must partner with the CIA to stop a deadly bombing.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/iu9qfUYyKsGQsexu5YJAEhSFAp0.jpg"
+					},
+					{
+						"airDate": "2017-01-18T00:00:00.000Z",
+						"episodeNumber": 12,
+						"name": "Devil Never Even Lived",
+						"overview": "When an unusual tattoo leads back to Roman, the team must decide whether to send him into the field...to go undercover with a dangerous biker gang.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/q86hqqrbORWm7XePNhU2vYmVqMV.jpg"
+					},
+					{
+						"airDate": "2017-02-08T00:00:00.000Z",
+						"episodeNumber": 13,
+						"name": "Name Not One Man",
+						"overview": "The team gets a major break in the Sandstorm case when they discover Shepherd's true identity...   and a decades-old connection between her and Weller.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/266xpxxqhsUEU6wtH7DSqM8Cgbj.jpg"
+					},
+					{
+						"airDate": "2017-02-15T00:00:00.000Z",
+						"episodeNumber": 14,
+						"name": "Borrow or Rob",
+						"overview": "A tattoo points the team toward a powerful collegiate secret society, but they can't infiltrate it without the help of one of its alumni...Rich Dotcom.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/aBNoRcrtVcqcLdlWSBLizoFYlXT.jpg"
+					},
+					{
+						"airDate": "2017-02-22T00:00:00.000Z",
+						"episodeNumber": 15,
+						"name": "Draw O Caesar, Erase a Coward",
+						"overview": "After a set of tattoos produces multiple leads, the team divides into unlikely pairings to chase down a deadly underworld courier.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/g72OqysWMff43j4X0RDb8qrBvcD.jpg"
+					},
+					{
+						"airDate": "2017-03-22T00:00:00.000Z",
+						"episodeNumber": 16,
+						"name": "Evil Did I Dwell, Lewd I Did Live",
+						"overview": "With Nas's help, Weller and Jane finally come face-to-face with Nas's inside source within Sandstorm, and square off with an old foe.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/qZ6NNf72yodZAcdO8faMkUGJhcl.jpg"
+					},
+					{
+						"airDate": "2017-03-29T00:00:00.000Z",
+						"episodeNumber": 17,
+						"name": "Solos",
+						"overview": "Jane and her new flame Oliver find themselves in a dangerous situation that exposes the secrets they've both been keeping.  Uncertain if they can trust each other, the couple must stay alive while Weller and the team race to save them.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/4Ylazj2nWuSdoMDgj6Z7YfpYqQs.jpg"
+					},
+					{
+						"airDate": "2017-04-05T00:00:00.000Z",
+						"episodeNumber": 18,
+						"name": "Senile Lines",
+						"overview": "Under investigation by an old rival, the team struggles to defend itself. Meanwhile, a tattoo leads them to a mysterious death at a foster home",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/5IiZs8KU7ieQTkUbjpNreEbeNtc.jpg"
+					},
+					{
+						"airDate": "2017-04-26T00:00:00.000Z",
+						"episodeNumber": 19,
+						"name": "Regard a Mere Mad Rager",
+						"overview": "Jane and Weller go undercover on a high-stakes scavenger hunt run by powerful hackers. Shepherd journeys to Thailand to procure a dangerous weapon.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/8mlMcLHWjElw2DoqzLuCk2EooHQ.jpg"
+					},
+					{
+						"airDate": "2017-05-03T00:00:00.000Z",
+						"episodeNumber": 20,
+						"name": "In Words, Drown I",
+						"overview": "Zapata's transgressions catch up to her, sending her to jail alongside a potentially powerful Sandstorm asset named Devon. Weller and the team must go to exceptional lengths to help Zapata out.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/6ZyxHPwVyETfWDT2MH1qCKvo3AC.jpg"
+					},
+					{
+						"airDate": "2017-05-10T00:00:00.000Z",
+						"episodeNumber": 21,
+						"name": "Mom",
+						"overview": "The team finally cracks a member of Sandstorm, leading to a huge breakthrough in uncovering Phase Two.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/qSiADjAqIBRc5ELDZejNFclwUyg.jpg"
+					},
+					{
+						"airDate": "2017-05-17T00:00:00.000Z",
+						"episodeNumber": 22,
+						"name": "Lepers Repel",
+						"overview": "As the FBI copes with a tragedy, Weller finds himself at the center of a surprising event. Jane faces an uncertain future.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/mqKrQjzOAxa2H7sH4QWB2Op5Aui.jpg"
+					}
+				],
+				"id": 79796,
+				"name": "Season 2",
+				"posterUrl": "https://image.tmdb.org/t/p/w500/4Fr3ufjp5rJW4r8sbkeO8RwAdFR.jpg",
+				"seasonNumber": 2
+			},
+			{
+				"airDate": "2017-10-27T00:00:00.000Z",
+				"episodes": [
+					{
+						"airDate": "2017-10-27T00:00:00.000Z",
+						"episodeNumber": 1,
+						"name": "Back to the Grind",
+						"overview": "18 months after parting ways under mysterious circumstances, the FBI team is brought back together by a new crisis.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/cBl8F5Ih1zRyRlhjuBYlkd2EzXy.jpg"
+					},
+					{
+						"airDate": "2017-11-03T00:00:00.000Z",
+						"episodeNumber": 2,
+						"name": "Enemy Bag of Tricks",
+						"overview": "As the team adjusts to their new dynamic -- and the new tattoos -- they battle a dangerous foreign power that is trying to hijack a satellite.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/e9PiDXfmTrJkJT4V9RJ6Sg6t0JW.jpg"
+					},
+					{
+						"airDate": "2017-11-10T00:00:00.000Z",
+						"episodeNumber": 3,
+						"name": "Upside Down Craft",
+						"overview": "While Jane and Weller hunt down a collective of dangerous computer hackers, Patterson and Rich Dot Com must work together to hide an explosive secret from their past.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/4k6pPnNqUeU3xoMueqcPnQJm4iv.jpg"
+					},
+					{
+						"airDate": "2017-11-17T00:00:00.000Z",
+						"episodeNumber": 4,
+						"name": "Gunplay Ricochet",
+						"overview": "As the team chases a deadly bomber who's terrorizing Manhattan, Jane uncovers a shattering secret from her youth.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/tDrkkeolufLdH6VDWgBu6iWwHrM.jpg"
+					},
+					{
+						"airDate": "2017-12-01T00:00:00.000Z",
+						"episodeNumber": 5,
+						"name": "This Profound Legacy",
+						"overview": "While Jane struggles to cope with a secret from her past, the team races to prevent an international crisis.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/b4tPSmx8o99a4vcJc1eeHDtK6b4.jpg"
+					},
+					{
+						"airDate": "2017-12-08T00:00:00.000Z",
+						"episodeNumber": 6,
+						"name": "Adoring Suspect",
+						"overview": "The team goes undercover on a movie set to stop a terrorist plot with unlikely backers. Roman blackmails Weller with a horrible secret about Jane.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/ulAm6ucLm99J8Lqf7gQdBqu2KB6.jpg"
+					},
+					{
+						"airDate": "2017-12-15T00:00:00.000Z",
+						"episodeNumber": 7,
+						"name": "Fix My Present Havoc",
+						"overview": "Facing a threat within the FBI, the team is forced to run a covert operation out of Jane and Weller's apartment. A tattoo leads to a doctor with a deadly secret.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/9FJNuKVkaHpVKoja4XICzuB53ut.jpg"
+					},
+					{
+						"airDate": "2017-12-22T00:00:00.000Z",
+						"episodeNumber": 8,
+						"name": "City Folk Under Wraps",
+						"overview": "As the team works together to take down a foe, Jane and Weller face a toxic secret that threatens to tear them apart.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/i61TSbERGK1cKDwiha5XcJRFQa5.jpg"
+					},
+					{
+						"airDate": "2018-01-12T00:00:00.000Z",
+						"episodeNumber": 9,
+						"name": "Hot Burning Flames",
+						"overview": "After some personal strife, the team must find a way to work together to track down missing nuclear warheads.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/gxCyiS0fUeWhmv6dzXV0rS9ZOiY.jpg"
+					},
+					{
+						"airDate": "2018-01-19T00:00:00.000Z",
+						"episodeNumber": 10,
+						"name": "Balance of Might",
+						"overview": "The team races to thwart a deadly terrorist plot with the help of Reade's journalist girlfriend.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/3H577vh8VXcQ0WtNe2myRs9boEB.jpg"
+					},
+					{
+						"airDate": "2018-01-26T00:00:00.000Z",
+						"episodeNumber": 11,
+						"name": "Technology Wizards",
+						"overview": "While Jane and Weller partner with a mysterious man from Jane's past to find a missing person, the team races to stop an arms deal.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/eToudSxieEVVCd97SUGS1DpuwEG.jpg"
+					},
+					{
+						"airDate": "2018-02-02T00:00:00.000Z",
+						"episodeNumber": 12,
+						"name": "Two Legendary Chums",
+						"overview": "Weller and his former FBI partner reunite for a dangerous undercover mission while Zapata interrogates a past foe.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/kOIv0V3GabM8Q9WooNJ3VjK68nh.jpg"
+					},
+					{
+						"airDate": "2018-03-02T00:00:00.000Z",
+						"episodeNumber": 13,
+						"name": "Warning Shot",
+						"overview": "A surprising visit from Nas leads the team to investigate a dangerous piece of technology that was stolen from the NSA. Roman and Blake  grow closer as they attend a high-stakes poker game.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/5ijPEzdn3Wno5nE9gNJwpNrCuWT.jpg"
+					},
+					{
+						"airDate": "2018-03-09T00:00:00.000Z",
+						"episodeNumber": 14,
+						"name": "Everlasting",
+						"overview": "When Patterson's investigation into a tattoo results in a horrible incident, she tries to figure out what went wrong - but quickly realizes all is not as it seems.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/gARLEMxUEXSI6GFLDqJVk26iEU1.jpg"
+					},
+					{
+						"airDate": "2018-03-16T00:00:00.000Z",
+						"episodeNumber": 15,
+						"name": "Deductions",
+						"overview": "The team must decide whether to trust a prisoner who warns them of a dangerous plot. Zapata is caught between the FBI and the CIA. Roman and Crawford butt heads over how to handle a volatile situation.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/3ejqgM9NDEtly8qnPQxhCHpRYIv.jpg"
+					},
+					{
+						"airDate": "2018-03-23T00:00:00.000Z",
+						"episodeNumber": 16,
+						"name": "Artful Dodge",
+						"overview": "A CIA source threatens to tear the team apart. Rich's place in the FBI is called into question. Roman and Crawford spend a day together under strange circumstances.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/ve3WCqwVyxFDrB2FwJea2ztPclw.jpg"
+					},
+					{
+						"airDate": "2018-03-30T00:00:00.000Z",
+						"episodeNumber": 17,
+						"name": "Mum's the Word",
+						"overview": "The FBI team and Avery attend a gala hosted by their target Hank Crawford in hopes of arresting him. Roman grows closer to the Crawfords.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/61OFEw3CYmLdZAGJPKcJAyovuLy.jpg"
+					},
+					{
+						"airDate": "2018-04-20T00:00:00.000Z",
+						"episodeNumber": 18,
+						"name": "Clamorous Night",
+						"overview": "Jane and her team must fight for their lives when Roman sends deadly assassins after them. Meanwhile, Patterson goes on a date, Reade contends with the O.P.R. inquisitor, Jane and Weller go to dinner, and Zapata attends a funeral.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/sEkAqgrhfePAs75INopxINKcG.jpg"
+					},
+					{
+						"airDate": "2018-04-27T00:00:00.000Z",
+						"episodeNumber": 19,
+						"name": "Galaxy of Minds",
+						"overview": "The team must partner with an oddball conspiracy theorist to keep Crawford from acquiring a deadly weapon. Meanwhile, Roman struggles to maintain his personal life with Blake while completing a series of secret missions.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/7ZbXeddyP4gtowHalHRT8bGZImM.jpg"
+					},
+					{
+						"airDate": "2018-05-04T00:00:00.000Z",
+						"episodeNumber": 20,
+						"name": "Let It Go",
+						"overview": "After receiving shocking news about Avery's father, Jane and Weller must hunt down an elusive criminal. Meanwhile, Patterson's father helps the team in the lab.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/ujsCqMSJLVcdJhWiouvLvvqitHy.jpg"
+					},
+					{
+						"airDate": "2018-05-11T00:00:00.000Z",
+						"episodeNumber": 21,
+						"name": "Defection",
+						"overview": "Jane is forced to recruit someone from her past to help take down a dangerous alliance.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/ktvXHX10JsR15pht89BBw36jZQc.jpg"
+					},
+					{
+						"airDate": "2018-05-18T00:00:00.000Z",
+						"episodeNumber": 22,
+						"name": "In Memory",
+						"overview": "Jane and Weller hunt Roman back to where it all started and attempt to stop him.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/b1nbYvYBT4V9vouFZUlA62WR2vt.jpg"
+					}
+				],
+				"id": 90314,
+				"name": "Season 3",
+				"posterUrl": "https://image.tmdb.org/t/p/w500/uVLXClxS7N9N2jNZHMjPCBNF31H.jpg",
+				"seasonNumber": 3
+			},
+			{
+				"airDate": "2018-10-12T00:00:00.000Z",
+				"episodes": [
+					{
+						"airDate": "2018-10-12T00:00:00.000Z",
+						"episodeNumber": 1,
+						"name": "Hella Duplicitous",
+						"overview": "The FBI team hunts a dangerous enemy operative, and a deadly new foe emerges.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/kCnA6kOWhEnmgkbaufrtAmc5bAK.jpg"
+					},
+					{
+						"airDate": "2018-10-19T00:00:00.000Z",
+						"episodeNumber": 2,
+						"name": "My Art Project",
+						"overview": "The entire intelligence community is put in jeopardy when Remi co-opts an FBI case.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/qlm2kuHrFZXuRLUvM3EkI4F8EPu.jpg"
+					},
+					{
+						"airDate": "2018-10-26T00:00:00.000Z",
+						"episodeNumber": 3,
+						"name": "The Quantico Affair",
+						"overview": "Patterson and Rich DotCom take the reigns as the FBI team faces an explosive threat.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/BWAnGOpKLKGDlxV1yLIqhxpNJa.jpg"
+					},
+					{
+						"airDate": "2018-11-02T00:00:00.000Z",
+						"episodeNumber": 4,
+						"name": "Sous-Vide",
+						"overview": "A decoded tattoo leads the team to a mysterious cache of dolls which turn out to be vehicles for biological weapons being sent around the world and now to the FBI. Jane exploits the fear of the weapons to advance her own plan to recover Shepherd.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/q6fFldpAlCiwHjPy0mTglMNrL6M.jpg"
+					},
+					{
+						"airDate": "2018-11-09T00:00:00.000Z",
+						"episodeNumber": 5,
+						"name": "Naughty Monkey Kicks At Tree",
+						"overview": "A blast from Rich DotCom's past sends the FBI team after a deadly terrorist plot.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/f5O24FJiGH7vz5WTEwEmqt04xIe.jpg"
+					},
+					{
+						"airDate": "2018-11-16T00:00:00.000Z",
+						"episodeNumber": 6,
+						"name": "Ca-Ca-Candidate For Cri-Cri-Crime",
+						"overview": "The team is drawn into dangerous political intrigue when a tattoo points to someone from Weitz's past.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/eOGqGdnCsYeQvS4VqwGsC7VPEXJ.jpg"
+					},
+					{
+						"airDate": "2018-11-30T00:00:00.000Z",
+						"episodeNumber": 7,
+						"name": "Case: Sun, Moon, and the Truth",
+						"overview": "Remi's schemes put her and Weller in danger, while Patterson and Rich solve a mysterious puzzle at the FBI.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/h25INYFcgwFWWFoTNS4PuToClMm.jpg"
+					},
+					{
+						"airDate": "2018-12-07T00:00:00.000Z",
+						"episodeNumber": 8,
+						"name": "Screech, Thwack, Pow",
+						"overview": "Remi races against the ever-worsening ZIP poisoning to enact her ultimate plan.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/bo2IGfIVdUCMkIakDZcb6tYUIhx.jpg"
+					},
+					{
+						"airDate": "2019-01-11T00:00:00.000Z",
+						"episodeNumber": 9,
+						"name": "Check Your Ed",
+						"overview": "The team's desperate gambit to get Jane back puts her head-to-head with Remi.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/kMXA03mfAdbSY8MPq1hCtfEy1o8.jpg"
+					},
+					{
+						"airDate": "2019-01-18T00:00:00.000Z",
+						"episodeNumber": 10,
+						"name": "The Big Reveal",
+						"overview": "Reade confronts Zapata, while the team follows a lead to a potential cure for Jane.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/ekdB7xq8EsRCZ0w5rDnLcmPASV2.jpg"
+					},
+					{
+						"airDate": "2019-02-01T00:00:00.000Z",
+						"episodeNumber": 11,
+						"name": "Careless Whisper",
+						"overview": "The murder of a best-selling true crime novelist sends Jane and the team on a hunt for a serial killer detailed in the author's final manuscript, which also features lightly fictionalized versions of the FBI team.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/aicwfhVy0cfrFEmNz1iDbCaA42X.jpg"
+					},
+					{
+						"airDate": "2019-02-08T00:00:00.000Z",
+						"episodeNumber": 12,
+						"name": "The Tale of the Book of Secrets",
+						"overview": "Roman's clues lead to a billionaire hypochondriac with stem cells that could cure Jane, who is now on her deathbed. Patterson and Rich offer to trade the Book of Secrets for the stem cells -- but first they'll have to get it.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/F98wt3iAwse8AcfHk8XZ7bghoB.jpg"
+					},
+					{
+						"airDate": "2019-02-15T00:00:00.000Z",
+						"episodeNumber": 13,
+						"name": "Though This Be Madness, Yet There Is Method In't",
+						"overview": "Jane and Weller's romantic getaway is cut short when the team must stop Madeline Burke's plans to blow up a building and crash a plane that turns out to be more than the average commercial airliner.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/e6HyHapD5LhvfkSdTEr4z1NK3KV.jpg"
+					},
+					{
+						"airDate": "2019-03-08T00:00:00.000Z",
+						"episodeNumber": 14,
+						"name": "The Big Blast from the Past Episode",
+						"overview": "An active bomber forces the team to delve into a case from their past.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/e33rGjxSZuU6Lb7iQroO3TjPtY0.jpg"
+					},
+					{
+						"airDate": "2019-03-15T00:00:00.000Z",
+						"episodeNumber": 15,
+						"name": "Frequently Recurring Struggle for Existence",
+						"overview": "Jane's past with Shepherd and Sandstorm both helps and hurts the team's efforts to stop the sale of a device that will weaponize stolen plutonium.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/vmxj5vru9j3rhMQruOooPI2Tjbu.jpg"
+					},
+					{
+						"airDate": "2019-03-22T00:00:00.000Z",
+						"episodeNumber": 16,
+						"name": "The One Where Jane Visits an Old Friend",
+						"overview": "Madeline escalates her plan, but the team isn't the only one chasing her down. Rich grows concerned for Boston’s well-being, and Jane seeks help from a familiar enemy.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/ukvRUXZnT25rYAhP9qmx3T21MDL.jpg"
+					},
+					{
+						"airDate": "2019-04-05T00:00:00.000Z",
+						"episodeNumber": 17,
+						"name": "The Night of the Dying Breath",
+						"overview": "The team races against the clock to save one of their own after Dominic enacts a nightmarish scheme in a bid for Madeline’s freedom. Tensions soar with Madeline as she makes her own demands.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/6UbkDVFr3jPkQOVlEAK6k1MVUEY.jpg"
+					},
+					{
+						"airDate": "2019-04-12T00:00:00.000Z",
+						"episodeNumber": 18,
+						"name": "'Ohana",
+						"overview": "Patterson's father, Bill Nye, returns for a case that pits the team against a pestiferous foe. Zapata goes rogue with an old friend. Jane and Weller continue their search for the hooded figure.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/rR0VkU0ZI5jib4i8NlZY0zG8QIW.jpg"
+					},
+					{
+						"airDate": "2019-04-19T00:00:00.000Z",
+						"episodeNumber": 19,
+						"name": "Everybody Hates Kathy",
+						"overview": "The team discovers an international conspiracy when a deadly weapon is stolen, Jane supports Weller when someone from his past dredges up painful memories, and Patterson and Rich contend with their newly released hacker accomplice.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/3zMQwex0RGgYAr6xxtSKT4XDsI2.jpg"
+					},
+					{
+						"airDate": "2019-05-24T00:00:00.000Z",
+						"episodeNumber": 20,
+						"name": "Coder to Killer",
+						"overview": "A horrifying and vengeful villain threatens the FBI. Weller considers his priorities. Zapata and Reade try to navigate their living situation. Patterson explores a budding interest.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/o05TkjaqN6QDiYJigVyLlvCT4RH.jpg"
+					},
+					{
+						"airDate": "2019-05-31T00:00:00.000Z",
+						"episodeNumber": 21,
+						"name": "Masters of War 1:5 - 8",
+						"overview": "Dominic begins to enact Madeline's cataclysmic scheme as the team rushes to stop him. Tensions rise as past secrets begin to unravel.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/okMLf0Mc3uIh1IS46UakBfz3sWz.jpg"
+					},
+					{
+						"airDate": "2019-05-31T00:00:00.000Z",
+						"episodeNumber": 22,
+						"name": "The Gang Gets Gone",
+						"overview": "The team sets out on an international mission to stop an attack from spreading. Madeline attempts to turn the tables as internal conflict threatens relationships within the team.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/8LT06LADFEZCAp3l8xqHpMdUyMP.jpg"
+					}
+				],
+				"id": 105458,
+				"name": "Season 4",
+				"posterUrl": "https://image.tmdb.org/t/p/w500/8XDeAdjVXXNvtu9Avrq7wRpC5D6.jpg",
+				"seasonNumber": 4
+			},
+			{
+				"airDate": "2020-05-07T00:00:00.000Z",
+				"episodes": [
+					{
+						"airDate": "2020-05-07T00:00:00.000Z",
+						"episodeNumber": 1,
+						"name": "I Came to Sleigh",
+						"overview": "Jane tries to pick up the pieces after the explosive finale in Iceland. She gets a strange message from an unknown ally that allows her to mount a rescue mission to free Rich Dotcom from a CIA black-site... but she'll need the help from her old rival Sho Akhtar.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/7etxLLWfzRyhJiy94Y1mUz1KSQ0.jpg"
+					},
+					{
+						"airDate": "2020-05-14T00:00:00.000Z",
+						"episodeNumber": 2,
+						"name": "We Didn't Start the Fire",
+						"overview": "Jane and the team reach out to Patterson's father in the hope of gaining access to a high-level conference in Finland where they hope to bring Matthew Weitz to their side.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/dyGYpFeKgyJEKFayckWgXc9LCLB.jpg"
+					},
+					{
+						"airDate": "2020-05-28T00:00:00.000Z",
+						"episodeNumber": 3,
+						"name": "Existential Ennui",
+						"overview": "When an op goes bad, the team must deal with a proverbial monster in their house before it can take them down one by one. Meanwhile, Director Weitz is forced into a tense game of psychological chess as Madeline Burke attempts to assess his loyalty and root out a potential mole at the FBI.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/pkOT1930yKwQtIXTvgPAcn9MFQd.jpg"
+					},
+					{
+						"airDate": "2020-06-04T00:00:00.000Z",
+						"episodeNumber": 4,
+						"name": "And My Axe!",
+						"overview": "In order to stop a terrorist group from procuring a deadly chemical weapon, the team must remember key details from their first days at the FBI. Meanwhile, Weller worries after he gets scary news about the health of his daughter.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/uDhF0dNgdDD7HtUzHsqVIFoe3Db.jpg"
+					},
+					{
+						"airDate": "2020-06-11T00:00:00.000Z",
+						"episodeNumber": 5,
+						"name": "Head Games",
+						"overview": "When Jane is shot and Weller is kidnapped, the team must fight to save both of their lives while maintaining the secrecy of their hidden base. Meanwhile, Weller is haunted by some dark ghosts from the past.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/8DebULzo0VWoFSVYl3MvmGaleoY.jpg"
+					},
+					{
+						"airDate": "2020-06-18T00:00:00.000Z",
+						"episodeNumber": 6,
+						"name": "Fire & Brimstone",
+						"overview": "When Ice Cream, the Icelandic fixer, returns to collect his debt, the team is forced into a life and death race around the world to solve a series of puzzles and recover the infamous stolen Gardner paintings.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/lwKd4gswGweCanpvW9kM0wt39DL.jpg"
+					},
+					{
+						"airDate": "2020-06-25T00:00:00.000Z",
+						"episodeNumber": 7,
+						"name": "Awl In",
+						"overview": "In an effort to stop Madeline from shipping two planes full of ZIP to the US, the team splits up into a high-stakes undercover mission where they intercept Madeline's son. Meanwhile, Madeline interrogates an old ally to get information on Kurt and the team.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/iORuvJ2H7d7egzYGSKdAZRScjF8.jpg"
+					},
+					{
+						"airDate": "2020-07-02T00:00:00.000Z",
+						"episodeNumber": 8,
+						"name": "Ghost Train",
+						"overview": "The team scrambles to get ahead of Madeline and Ivy as they close in on the bunker's location, but someone on the inside is feeding Madeline information. As her plan takes shape, the team may be forced to take desperate measures.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/xQWAnSbNUPQaec14pyGojrvVffE.jpg"
+					},
+					{
+						"airDate": "2020-07-09T00:00:00.000Z",
+						"episodeNumber": 10,
+						"name": "Love You to Bits and Bytes",
+						"overview": "As Ivy races to retrieve the devastating stash of ZIP bombs, the remaining members of the team must rely on the help of a longtime thorn in their side, the very unstable genius Kathy Gustafson.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/21PuAMCzIsZhfvY7055IbLDTPKE.jpg"
+					},
+					{
+						"airDate": "2020-07-09T00:00:00.000Z",
+						"episodeNumber": 9,
+						"name": "Brass Tacks",
+						"overview": "With the surviving members of the team captured and held in FBI custody, Madeline and Ivy are in the final stages of their plan, but a few unlikely allies come out from the woodwork, trying to stop her before it's too late.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/ml8uOb9STuP1ZgLr1ejp3mS0SJ.jpg"
+					},
+					{
+						"airDate": "2020-07-23T00:00:00.000Z",
+						"episodeNumber": 11,
+						"name": "Iunne Ennui",
+						"overview": "Turn off your mind, relax and float down stream...it is not dying...it is not dying.",
+						"stillUrl": "https://image.tmdb.org/t/p/w500/dJ8pjCmUVSEOR6ilEABSKbi16KT.jpg"
+					}
+				],
+				"id": 146859,
+				"name": "Season 5",
+				"posterUrl": "https://image.tmdb.org/t/p/w500/53LSbDuXCJXx2SzAVynLuitbE2X.jpg",
+				"seasonNumber": 5
+			}
+		],
+		"status": "Ended",
+		"tagline": "Piecing together her past. One tattoo at a time.",
+		"tmdbId": 62710,
+		"type": "Scripted",
+		"updatedAt": "2026-02-27T16:42:46.911Z",
+		"backdropUrl": "https://media.themoviedb.org/t/p/w1920_and_h800_multi_faces/1GWiao0QYuKsoTvUmd7ivnE3qDY.jpg"
+	}
+]

--- a/src/routes/tv/index.tsx
+++ b/src/routes/tv/index.tsx
@@ -1,0 +1,154 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { CardItem } from "@/components/cards/card.tsx";
+import { Grid } from "@/components/layouts/grid.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import {
+	Carousel,
+	CarouselContent,
+	CarouselItem,
+	CarouselNext,
+	CarouselPrevious,
+} from "@/components/ui/carousel.tsx";
+import series from "@/lib/mockups/series.json";
+
+export const Route = createFileRoute("/tv/")({
+	component: SerieRoute,
+});
+
+function SerieRoute() {
+	const { t } = useTranslation();
+
+	return (
+		<div className="mx-auto w-full">
+			<Carousel
+				className="w-full"
+				opts={{
+					loop: true,
+					align: "center",
+				}}
+			>
+				<CarouselContent>
+					{series.map((serie) => {
+						return (
+							<CarouselItem key={serie.id}>
+								<div className="relative w-full overflow-hidden rounded-xl border border-border">
+									<img
+										src={serie.backdropUrl}
+										className="w-full h-60 md:h-120 object-cover"
+										alt={serie.name}
+									/>
+
+									<div className="absolute inset-0 bg-linear-to-t from-malachite-500/80 via-malachite-500/30 to-transparent" />
+
+									<div className="absolute inset-0 p-8 flex flex-col justify-end gap-4">
+										<h2 className="text-4xl font-bold drop-shadow-lg">
+											{serie.name}
+										</h2>
+
+										<div className="max-w-2xl hidden md:block">
+											<p className="text-lg line-clamp-2 text-white/90 drop-shadow-md">
+												{serie.tagline}
+											</p>
+										</div>
+
+										<Link
+											to={`/serie/${serie.id}`}
+											className="bg-primary text-primary-foreground w-fit px-6 py-2 rounded-full font-semibold hover:brightness-110 transition-all shadow-lg"
+										>
+											{t("common:viewDetails")}
+										</Link>
+									</div>
+								</div>
+							</CarouselItem>
+						);
+					})}
+				</CarouselContent>
+				<CarouselPrevious
+					variant="default"
+					className="left-4 bg-white border-none hover:bg-white/80 z-10"
+				/>
+				<CarouselNext
+					variant="default"
+					className="right-4 bg-white border-none hover:bg-white/80 z-10"
+				/>
+			</Carousel>
+			<div className="py-6 space-y-4">
+				<div className="flex items-center justify-between mb-4">
+					<p className="text-2xl font-bold">{t("common:trending")}</p>
+					<Button>{t("pages:donate.viewAll")}</Button>
+				</div>
+				<Grid minColSize={"120px"} className={"grid-cols-5"}>
+					{series.map((serie) => (
+						<CardItem
+							title={serie.name}
+							url={`/serie/${serie.id}`}
+							imageURL={serie.posterUrl}
+							rating={serie.rating || 0}
+							year={new Date(serie.firstAirDate).getFullYear()}
+							synopsis={serie.tagline}
+							mediaType={"tv-show"}
+							key={serie.id}
+						/>
+					))}
+				</Grid>
+				<div className="flex items-center justify-between mb-4">
+					<p className="text-2xl font-bold">{t("common:mostPopular")}</p>
+					<Button>{t("pages:donate.viewAll")}</Button>
+				</div>
+				<Grid minColSize={"120px"} className={"grid-cols-5"}>
+					{series.map((serie) => (
+						<CardItem
+							title={serie.name}
+							url={`/serie/${serie.id}`}
+							imageURL={serie.posterUrl}
+							rating={serie.rating || 0}
+							year={new Date(serie.firstAirDate).getFullYear()}
+							synopsis={serie.tagline}
+							mediaType={"tv-show"}
+							key={serie.id}
+						/>
+					))}
+				</Grid>
+				<div className="flex items-center justify-between mb-4">
+					<p className="text-2xl font-bold">
+						{t("library:statusAir.currentlyAiring")}
+					</p>
+					<Button>{t("pages:donate.viewAll")}</Button>
+				</div>
+				<Grid minColSize={"120px"} className={"grid-cols-5"}>
+					{series.map((serie) => (
+						<CardItem
+							title={serie.name}
+							url={`/serie/${serie.id}`}
+							imageURL={serie.posterUrl}
+							rating={serie.rating || 0}
+							year={new Date(serie.firstAirDate).getFullYear()}
+							synopsis={serie.tagline}
+							mediaType={"tv-show"}
+							key={serie.id}
+						/>
+					))}
+				</Grid>
+				<div className="flex items-center justify-between mb-4">
+					<p className="text-2xl font-bold">{t("common:comingSoon")}</p>
+					<Button>{t("pages:donate.viewAll")}</Button>
+				</div>
+				<Grid minColSize={"120px"} className={"grid-cols-5"}>
+					{series.map((serie) => (
+						<CardItem
+							title={serie.name}
+							url={`/serie/${serie.id}`}
+							imageURL={serie.posterUrl}
+							rating={serie.rating || 0}
+							year={new Date(serie.firstAirDate).getFullYear()}
+							synopsis={serie.tagline}
+							mediaType={"tv-show"}
+							key={serie.id}
+						/>
+					))}
+				</Grid>
+			</div>
+		</div>
+	);
+}

--- a/src/routes/tv/index.tsx
+++ b/src/routes/tv/index.tsx
@@ -53,7 +53,7 @@ function SerieRoute() {
 										</div>
 
 										<Link
-											to={`/serie/${serie.id}`}
+											to={`/tv/${serie.id}`}
 											className="bg-primary text-primary-foreground w-fit px-6 py-2 rounded-full font-semibold hover:brightness-110 transition-all shadow-lg"
 										>
 											{t("common:viewDetails")}
@@ -82,7 +82,7 @@ function SerieRoute() {
 					{series.map((serie) => (
 						<CardItem
 							title={serie.name}
-							url={`/serie/${serie.id}`}
+							url={`/tv/${serie.id}`}
 							imageURL={serie.posterUrl}
 							rating={serie.rating || 0}
 							year={new Date(serie.firstAirDate).getFullYear()}
@@ -100,7 +100,7 @@ function SerieRoute() {
 					{series.map((serie) => (
 						<CardItem
 							title={serie.name}
-							url={`/serie/${serie.id}`}
+							url={`/tv/${serie.id}`}
 							imageURL={serie.posterUrl}
 							rating={serie.rating || 0}
 							year={new Date(serie.firstAirDate).getFullYear()}
@@ -120,7 +120,7 @@ function SerieRoute() {
 					{series.map((serie) => (
 						<CardItem
 							title={serie.name}
-							url={`/serie/${serie.id}`}
+							url={`/tv/${serie.id}`}
 							imageURL={serie.posterUrl}
 							rating={serie.rating || 0}
 							year={new Date(serie.firstAirDate).getFullYear()}
@@ -138,7 +138,7 @@ function SerieRoute() {
 					{series.map((serie) => (
 						<CardItem
 							title={serie.name}
-							url={`/serie/${serie.id}`}
+							url={`/tv/${serie.id}`}
 							imageURL={serie.posterUrl}
 							rating={serie.rating || 0}
 							year={new Date(serie.firstAirDate).getFullYear()}


### PR DESCRIPTION
## Description
Added a new `/series` route showcasing mock data for TV shows, including seasons, episodes, cast, crew, and metadata. Updated header links and layouts to align with existing routes like `/anime` and `/game`. Closes #77 

## Acknowledgements
- [x] I read the [PR Guidelines](https://github.com/TrackGeek/web/blob/main/.github/CONTRIBUTING.md)
- [x] I linted and formatted the code by running `npm run check`
- [x] The PR title follows the repo's [commit conventions](https://github.com/TrackGeek/web/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    At least TWO screenshots of the feature
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a TV section accessible from the header that links to /tv.
  * Added a /tv page with a featured carousel showcasing series (backdrops, titles, taglines) and a "View Details" flow.
  * Added categorized series sections: Trending, Most Popular, Currently Airing, and Coming Soon, each showing posters, ratings, year, and synopsis.
  * Added a new localized label: "Trending".
* **Chores**
  * Included sample series data to populate the TV content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->