### PR TITLE
feat(movies): add `/movie` route with detailed mock data and update h…

### DIFF
--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -181,7 +181,7 @@ export function Header() {
 							</Link>
 						</DropdownMenuItem>
 						<DropdownMenuItem asChild>
-							<Link to="/" className="cursor-pointer">
+							<Link to="/movie" className="cursor-pointer">
 								<Clapperboard size={18} className="text-white" />
 								{t("common:types.movie_other")}
 							</Link>

--- a/src/lib/mockups/movies.json
+++ b/src/lib/mockups/movies.json
@@ -1,0 +1,2037 @@
+[
+	{
+		"belongsToCollection": {
+			"backdropUrl": "https://image.tmdb.org/t/p/w500/ipu7wJghURt4QOecgHO0tEP0qHp.jpg",
+			"name": "300 Collection",
+			"posterUrl": "https://image.tmdb.org/t/p/w500/nKQqh6kJvPdpOJD24enD3Bm1Hy5.jpg"
+		},
+		"budget": 65000000,
+		"cast": [
+			{
+				"character": "Armless Concubine",
+				"id": 1330753,
+				"name": "Vervi Mauricio",
+				"profileUrl": null
+			},
+			{
+				"character": "Astinos",
+				"id": 17292,
+				"name": "Tom Wisdom",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/84jgVW6GGeha5T3FsFwN6BQ4qOu.jpg"
+			},
+			{
+				"character": "Blacksmith",
+				"id": 1330754,
+				"name": "Charles Papasoff",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/vL2kwNoVwxDsNcYRL7K7vwQ2HGZ.jpg"
+			},
+			{
+				"character": "Boy #1 at Market",
+				"id": 1330757,
+				"name": "David Thibodeau",
+				"profileUrl": null
+			},
+			{
+				"character": "Burned Village Child",
+				"id": 1089929,
+				"name": "Alexandra Beaton",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/luBazgWtZeK6WAaPKb9JUBPB0id.jpg"
+			},
+			{
+				"character": "Captain",
+				"id": 9831,
+				"name": "Vincent Regan",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/7VHu79GciN5QlQTmWdBS86eE2mu.jpg"
+			},
+			{
+				"character": "Concubine",
+				"id": 1330759,
+				"name": "Andreanne Ross",
+				"profileUrl": null
+			},
+			{
+				"character": "Concubine",
+				"id": 1330760,
+				"name": "Sara Giacalone",
+				"profileUrl": null
+			},
+			{
+				"character": "Contortionist",
+				"id": 1330766,
+				"name": "Sandrine Merette-Attiow",
+				"profileUrl": null
+			},
+			{
+				"character": "Councilman",
+				"id": 218899,
+				"name": "John Dunn-Hill",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/gyTy14cdl7XIDLA6rpRtnOO5GA.jpg"
+			},
+			{
+				"character": "Dancer",
+				"id": 1330768,
+				"name": "Ruan Vibegaard",
+				"profileUrl": null
+			},
+			{
+				"character": "Dancer",
+				"id": 190088,
+				"name": "Danielle Hubbard",
+				"profileUrl": null
+			},
+			{
+				"character": "Dancer",
+				"id": 2603206,
+				"name": "Elisabeth Etienne",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/eaAzW1rf6uEVnvPdLAZhmBhCkwI.jpg"
+			},
+			{
+				"character": "Daughter at Market (3/5 years old)",
+				"id": 1203045,
+				"name": "Veronique-Natale Szalankiewicz",
+				"profileUrl": null
+			},
+			{
+				"character": "Daxos",
+				"id": 17291,
+				"name": "Andrew Pleavin",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/hp20HveWeBveVYtE87DPwmXEpD2.jpg"
+			},
+			{
+				"character": "Dilios",
+				"id": 1371,
+				"name": "David Wenham",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/F7CWSqUE75HtrcdqIQ7UMZ9aTX.jpg"
+			},
+			{
+				"character": "Elder Councilman",
+				"id": 29463,
+				"name": "Michael Sinelnikoff",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/uY2vabps2KlAyRutRtGyxk0SOqy.jpg"
+			},
+			{
+				"character": "Ephialtes",
+				"id": 17290,
+				"name": "Andrew Tiernan",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/dD32tMcONax0lmLw9nwyAf43mlN.jpg"
+			},
+			{
+				"character": "Ephor #1",
+				"id": 306574,
+				"name": "Greg Kramer",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/rCRFy3UPrJZM1e43EY5rtwnn8i1.jpg"
+			},
+			{
+				"character": "Ephor #2",
+				"id": 96594,
+				"name": "Alex Ivanovici",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/kna1yZIKo5CM1V22zzbaeD1JEe0.jpg"
+			},
+			{
+				"character": "Ephor #3",
+				"id": 1233013,
+				"name": "Tom Rack",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/4pB79oFOqGD8njh0xbE306i9zMc.jpg"
+			},
+			{
+				"character": "Ephor #4",
+				"id": 119708,
+				"name": "David Francis",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/vnlgdwXnahVw8j0TokPqxPnvRnU.jpg"
+			},
+			{
+				"character": "Ephor #5",
+				"id": 29468,
+				"name": "James Bradford",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/eY4jfjviQUsa97Uc5Kp9UGSkWuW.jpg"
+			},
+			{
+				"character": "Executioner",
+				"id": 1330751,
+				"name": "Leon Laderach",
+				"profileUrl": null
+			},
+			{
+				"character": "Fighting Boy (12 years old)",
+				"id": 1089921,
+				"name": "Sebastian St. Germain",
+				"profileUrl": null
+			},
+			{
+				"character": "Free Greek-Baker",
+				"id": 143395,
+				"name": "Marcel Jeannin",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/u4cJlSYUA5T2dHQrR5meN23tHda.jpg"
+			},
+			{
+				"character": "Free Greek-Blacksmith",
+				"id": 131338,
+				"name": "Kent McQuaid",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/hxKC3Xk36sqwjadwW9F0agBfGPd.jpg"
+			},
+			{
+				"character": "Free Greek-Potter",
+				"id": 90467,
+				"name": "Andrew Shaver",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/6W89t1kbnI9dWUVUT0fwTotufsd.jpg"
+			},
+			{
+				"character": "Free Greek-Sculptor",
+				"id": 1142866,
+				"name": "Robin Wilcock",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/xhHtLXxKzl2vPPGechAztbbwPE0.jpg"
+			},
+			{
+				"character": "Giant with Arrow",
+				"id": 1330779,
+				"name": "Camille Rizkallah",
+				"profileUrl": null
+			},
+			{
+				"character": "Girl at Market",
+				"id": 1177458,
+				"name": "Maéva Nadon",
+				"profileUrl": null
+			},
+			{
+				"character": "Gorgo",
+				"id": 17286,
+				"name": "Lena Headey",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/xR2IBnBlUdyBe5hecaVdtRuQqUE.jpg"
+			},
+			{
+				"character": "King Leonidas",
+				"id": 17276,
+				"name": "Gerard Butler",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/i54XoxYieuff2w6MwyfwVUBvmR0.jpg"
+			},
+			{
+				"character": "Kissing Concubine",
+				"id": 1330762,
+				"name": "Ariadne Bourbonnière",
+				"profileUrl": null
+			},
+			{
+				"character": "Kissing Concubine",
+				"id": 1330764,
+				"name": "Isabelle Fournel",
+				"profileUrl": null
+			},
+			{
+				"character": "Leonidas @ 15 yrs",
+				"id": 17294,
+				"name": "Tyler Neitzel",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/ao58ky4lkAzJztfz7lKdjSms71r.jpg"
+			},
+			{
+				"character": "Leonidas @ 7/8 yrs",
+				"id": 963118,
+				"name": "Eli Snyder",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/eywe0OngH7cxHcMB8dgjxgTBEtK.jpg"
+			},
+			{
+				"character": "Leonidas' Father",
+				"id": 1089920,
+				"name": "Tim Connolly",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/h9QAyc5esNHzn2lWUvLozD1LAnx.jpg"
+			},
+			{
+				"character": "Leonidas' Mother",
+				"id": 181248,
+				"name": "Marie-Julie Rivest",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/o4qpSYGigxyIGL8fnTTz6HDLH8o.jpg"
+			},
+			{
+				"character": "Litter Bearer/Slave",
+				"id": 1330781,
+				"name": "Neon Cobran",
+				"profileUrl": null
+			},
+			{
+				"character": "Long Neck Woman",
+				"id": 1330780,
+				"name": "Trudi Hanley",
+				"profileUrl": null
+			},
+			{
+				"character": "Loyalist",
+				"id": 230,
+				"name": "Stephen McHattie",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/zqOwiEDXYM9AKQgHGJGeIp7QkPh.jpg"
+			},
+			{
+				"character": "Messenger",
+				"id": 68278,
+				"name": "Peter Mensah",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/t94TFc6f71AUmZFqdaQfjr7LTRp.jpg"
+			},
+			{
+				"character": "Mother at Market",
+				"id": 1330755,
+				"name": "Isabelle Champeau",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/xltupoxog8FwuASxf2YHeb1SbDc.jpg"
+			},
+			{
+				"character": "Oracle Girl",
+				"id": 1089919,
+				"name": "Kelly Craig",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/AeXj9nfhm05e0HgIVkPlf3SJVC1.jpg"
+			},
+			{
+				"character": "Other Council Guard",
+				"id": 70786,
+				"name": "Jean Michel Paré",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/tU5YL4ekpCpOgUtGSGXkCJaTVvV.jpg"
+			},
+			{
+				"character": "Partisan",
+				"id": 115596,
+				"name": "Arthur Holden",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/c8FXyHhiVXCsjvwxXOzuVi28z3i.jpg"
+			},
+			{
+				"character": "Persian Emissary",
+				"id": 181247,
+				"name": "Tyrone Benskin",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/jJ4xLfwYsK2iDL1Ge8u2FvlKCb9.jpg"
+			},
+			{
+				"character": "Persian General Slaughtered",
+				"id": 1330752,
+				"name": "Dave Lapommeray",
+				"profileUrl": null
+			},
+			{
+				"character": "Persian General",
+				"id": 102742,
+				"name": "Patrick Sabongui",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/yI8xBqEi5IAeyoEgGcdbcyEc9vO.jpg"
+			},
+			{
+				"character": "Persian General",
+				"id": 1330758,
+				"name": "Stewart Myiow",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/uvMYpu3KiWOTn2PoZpK9LQhq4yB.jpg"
+			},
+			{
+				"character": "Persian",
+				"id": 207881,
+				"name": "Kwasi Songui",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/ygIdWB97Mt2DHhVsH7J4Ti2aVZF.jpg"
+			},
+			{
+				"character": "Pleistarchos",
+				"id": 17293,
+				"name": "Giovani Cimmino",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/pIhu7xSZEmO4WWkuZSDLq2ZlThu.jpg"
+			},
+			{
+				"character": "Potter",
+				"id": 1177316,
+				"name": "David Schaap",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/4ah8qMW4MC9IaYh7SXiI2pMTy2j.jpg"
+			},
+			{
+				"character": "Sentry #1",
+				"id": 47934,
+				"name": "Dylan Smith",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/khDLIA2yy2hVrD4uLYt9EAUYTj6.jpg"
+			},
+			{
+				"character": "Sentry #2",
+				"id": 125686,
+				"name": "Maurizio Terrazzano",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/7jDtZGPpavhKa4DtFsNmsDYHcT1.jpg"
+			},
+			{
+				"character": "Slave Girl",
+				"id": 119250,
+				"name": "Mercedes Leggett",
+				"profileUrl": null
+			},
+			{
+				"character": "Slave Girl",
+				"id": 1297965,
+				"name": "Stéphanie Aubry",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/6xa1T9QDda3G0T9FPGy3pPKUloE.jpg"
+			},
+			{
+				"character": "Slave Girl",
+				"id": 1330769,
+				"name": "Geneviève Guilbault",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/3Dk5jnS9RJoWPGMqQCXtUct3kc3.jpg"
+			},
+			{
+				"character": "Slave Girl",
+				"id": 1330770,
+				"name": "Bonnie Mak",
+				"profileUrl": null
+			},
+			{
+				"character": "Slave Girl",
+				"id": 1330771,
+				"name": "Caroline Aspirot",
+				"profileUrl": null
+			},
+			{
+				"character": "Slave Girl",
+				"id": 1330772,
+				"name": "Gina Gagnon",
+				"profileUrl": null
+			},
+			{
+				"character": "Slave Girl",
+				"id": 1330773,
+				"name": "Tania Trudel",
+				"profileUrl": null
+			},
+			{
+				"character": "Slave Girl",
+				"id": 1330774,
+				"name": "Stephania Gambaroff",
+				"profileUrl": null
+			},
+			{
+				"character": "Slave Girl",
+				"id": 1330775,
+				"name": "Chanelle Lamothe",
+				"profileUrl": null
+			},
+			{
+				"character": "Slave Girl",
+				"id": 1330776,
+				"name": "Sabrina-Jasmine Guilbault",
+				"profileUrl": null
+			},
+			{
+				"character": "Slave Girl",
+				"id": 84586,
+				"name": "Amélie Sorel",
+				"profileUrl": null
+			},
+			{
+				"character": "Spartan Baby A",
+				"id": 1330745,
+				"name": "Loucas Minchillo",
+				"profileUrl": null
+			},
+			{
+				"character": "Spartan Baby B",
+				"id": 1330746,
+				"name": "Nicholas Minchillo",
+				"profileUrl": null
+			},
+			{
+				"character": "Spartan Baby Inspector",
+				"id": 1089927,
+				"name": "Dennis St John",
+				"profileUrl": null
+			},
+			{
+				"character": "Spartan Boy",
+				"id": 1330750,
+				"name": "Jeremy Thibodeau",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/AdM7JNFgQ2sBtuaTYhg8NWmrnmc.jpg"
+			},
+			{
+				"character": "Spartan General #2",
+				"id": 1330749,
+				"name": "Jere Gillis",
+				"profileUrl": null
+			},
+			{
+				"character": "Spartan General",
+				"id": 1089928,
+				"name": "Robert Paradis",
+				"profileUrl": null
+			},
+			{
+				"character": "Spartan with Stick",
+				"id": 105496,
+				"name": "Neil Napier",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/HlBLkxkiD4rVehF0RKkHSmmIKf.jpg"
+			},
+			{
+				"character": "Statesman",
+				"id": 1089930,
+				"name": "Frédéric Smith",
+				"profileUrl": null
+			},
+			{
+				"character": "Stelios",
+				"id": 17288,
+				"name": "Michael Fassbender",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/xvbnUiB2ZBR3QIt595OzNy657Vw.jpg"
+			},
+			{
+				"character": "Theron",
+				"id": 17287,
+				"name": "Dominic West",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/6y2M3EWslBPwPlugEFg8XDHfSJ0.jpg"
+			},
+			{
+				"character": "Transsexual (Arabian) #3",
+				"id": 1330778,
+				"name": "Atif Y. Siddiqi",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/xZCOkAApPuxO3imwTVxoQiK8HmT.jpg"
+			},
+			{
+				"character": "Transsexual (Asian) #1",
+				"id": 1330777,
+				"name": "Manny Cortez Tuazon",
+				"profileUrl": null
+			},
+			{
+				"character": "Transsexual (Asian) #2",
+				"id": 4138285,
+				"name": "Cindy",
+				"profileUrl": null
+			},
+			{
+				"character": "Uber Immortal (Giant)",
+				"id": 112692,
+				"name": "Robert Maillet",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/2P5kMGJm4iIJvocwuwM9IbJqoah.jpg"
+			},
+			{
+				"character": "Ubermortal Vocals (voice)",
+				"id": 1077782,
+				"name": "Gary A. Hecker",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/cEs5VifZGciPAXiCCYlGqzTnhmX.jpg"
+			},
+			{
+				"character": "Xerxes",
+				"id": 17289,
+				"name": "Rodrigo Santoro",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/d3MaF9SPHDn2PMYHuqdnO0Csik6.jpg"
+			}
+		],
+		"createdAt": "2026-02-27T18:20:21.024Z",
+		"crew": [
+			{
+				"id": 1075261,
+				"job": "Visual Effects Supervisor",
+				"name": "Chris Watts",
+				"profileUrl": null
+			},
+			{
+				"id": 1079559,
+				"job": "Visual Effects Assistant Editor",
+				"name": "Alejandro Valdés-Rochin",
+				"profileUrl": null
+			},
+			{
+				"id": 1081488,
+				"job": "Stunts",
+				"name": "Doug Chapman",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/woJlBx2I4Hv1nKkC8f1G5cXqvXu.jpg"
+			},
+			{
+				"id": 1102071,
+				"job": "Executive Producer",
+				"name": "Craig J. Flores",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/xhXUaqBqfNfFDBKxlCmG7nE892N.jpg"
+			},
+			{
+				"id": 1128035,
+				"job": "Techno Crane Operator",
+				"name": "David Uloth",
+				"profileUrl": null
+			},
+			{
+				"id": 113097,
+				"job": "Sound Designer",
+				"name": "Derek Vanderhorst",
+				"profileUrl": null
+			},
+			{
+				"id": 113097,
+				"job": "Sound Effects Editor",
+				"name": "Derek Vanderhorst",
+				"profileUrl": null
+			},
+			{
+				"id": 113122,
+				"job": "Visual Effects Supervisor",
+				"name": "Thierry Delattre",
+				"profileUrl": null
+			},
+			{
+				"id": 113123,
+				"job": "Visual Effects Coordinator",
+				"name": "Anouk Deveault-Moreau",
+				"profileUrl": null
+			},
+			{
+				"id": 113137,
+				"job": "Visual Effects Supervisor",
+				"name": "Jeremy Hunt",
+				"profileUrl": null
+			},
+			{
+				"id": 113140,
+				"job": "Visual Effects Producer",
+				"name": "Daniel Leduc",
+				"profileUrl": null
+			},
+			{
+				"id": 113145,
+				"job": "Visual Effects Supervisor",
+				"name": "Richard Martin",
+				"profileUrl": null
+			},
+			{
+				"id": 11420,
+				"job": "Producer",
+				"name": "Gianni Nunnari",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/fGzLjhVk6ojkcEtOJJE3fEudGwE.jpg"
+			},
+			{
+				"id": 1194066,
+				"job": "Key Makeup Artist",
+				"name": "Nathalie Trépanier",
+				"profileUrl": null
+			},
+			{
+				"id": 1194085,
+				"job": "3D Tracking Layout",
+				"name": "Jean-Francois Morissette",
+				"profileUrl": null
+			},
+			{
+				"id": 1198825,
+				"job": "Casting Associate",
+				"name": "Randi Wells",
+				"profileUrl": null
+			},
+			{
+				"id": 1198826,
+				"job": "Costume Illustrator",
+				"name": "Simonetta Mariano",
+				"profileUrl": null
+			},
+			{
+				"id": 1204225,
+				"job": "Set Designer",
+				"name": "Brent Lambert",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/dExHog38nnNNHeelJUSulXHH6Sr.jpg"
+			},
+			{
+				"id": 1209419,
+				"job": "Stunts",
+				"name": "Tim Rigby",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/5ckhBJzA3MNxGPDSWytTKrdm26M.jpg"
+			},
+			{
+				"id": 1209419,
+				"job": "Utility Stunts",
+				"name": "Tim Rigby",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/5ckhBJzA3MNxGPDSWytTKrdm26M.jpg"
+			},
+			{
+				"id": 1272667,
+				"job": "Screenplay",
+				"name": "Michael B. Gordon",
+				"profileUrl": null
+			},
+			{
+				"id": 1299980,
+				"job": "Assistant Costume Designer",
+				"name": "Christine Bieselin Clark",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/1qCeTY9vp5LKQJGa1pqTNRFQDr6.jpg"
+			},
+			{
+				"id": 13061,
+				"job": "Additional Casting",
+				"name": "David Rapaport",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/Ai46ihtsE18QWKZGDEJ8AWiymqH.jpg"
+			},
+			{
+				"id": 1317043,
+				"job": "Costumer",
+				"name": "Azalia Snail",
+				"profileUrl": null
+			},
+			{
+				"id": 1327213,
+				"job": "Hairstylist",
+				"name": "Michelle Côté",
+				"profileUrl": null
+			},
+			{
+				"id": 1327222,
+				"job": "Set Decoration",
+				"name": "Philippe Lord",
+				"profileUrl": null
+			},
+			{
+				"id": 1327907,
+				"job": "Art Direction",
+				"name": "Jean-Pierre Paquet",
+				"profileUrl": null
+			},
+			{
+				"id": 1327909,
+				"job": "Makeup Department Head",
+				"name": "Scott Wheeler",
+				"profileUrl": null
+			},
+			{
+				"id": 1327910,
+				"job": "Costume Supervisor",
+				"name": "Lyse Pomerleau",
+				"profileUrl": null
+			},
+			{
+				"id": 1342658,
+				"job": "Dialogue Editor",
+				"name": "Frederick H. Stahly",
+				"profileUrl": null
+			},
+			{
+				"id": 1368864,
+				"job": "Sound Re-Recording Mixer",
+				"name": "Chris Jenkins",
+				"profileUrl": null
+			},
+			{
+				"id": 1368877,
+				"job": "CG Supervisor",
+				"name": "Danielle Plantec",
+				"profileUrl": null
+			},
+			{
+				"id": 1368885,
+				"job": "Transportation Coordinator",
+				"name": "Collin Butrum",
+				"profileUrl": null
+			},
+			{
+				"id": 1374169,
+				"job": "Foley Artist",
+				"name": "Michael J. Broomberg",
+				"profileUrl": null
+			},
+			{
+				"id": 1384358,
+				"job": "Set Designer",
+				"name": "Vincent Gingras-Liberali",
+				"profileUrl": null
+			},
+			{
+				"id": 1384366,
+				"job": "Boom Operator",
+				"name": "Maxime Ferland",
+				"profileUrl": null
+			},
+			{
+				"id": 1384392,
+				"job": "Dresser",
+				"name": "Julie Amyot",
+				"profileUrl": null
+			},
+			{
+				"id": 1384394,
+				"job": "Transportation Coordinator",
+				"name": "Daniel Matthews",
+				"profileUrl": null
+			},
+			{
+				"id": 1384395,
+				"job": "Transportation Captain",
+				"name": "John Bober",
+				"profileUrl": null
+			},
+			{
+				"id": 1391725,
+				"job": "Visual Effects Producer",
+				"name": "Chad Malbon",
+				"profileUrl": null
+			},
+			{
+				"id": 1391751,
+				"job": "Set Designer",
+				"name": "Frédéric Amblard",
+				"profileUrl": null
+			},
+			{
+				"id": 1391756,
+				"job": "Set Designer",
+				"name": "Alex Touikan",
+				"profileUrl": null
+			},
+			{
+				"id": 1391759,
+				"job": "Property Master",
+				"name": "Denis Hamel",
+				"profileUrl": null
+			},
+			{
+				"id": 1391760,
+				"job": "Sculptor",
+				"name": "Lucie Fournier",
+				"profileUrl": null
+			},
+			{
+				"id": 1392099,
+				"job": "Visual Effects Producer",
+				"name": "Michael Meagher",
+				"profileUrl": null
+			},
+			{
+				"id": 1392106,
+				"job": "Still Photographer",
+				"name": "Takashi Seida",
+				"profileUrl": null
+			},
+			{
+				"id": 1392906,
+				"job": "Visual Effects Producer",
+				"name": "Gayle Busby",
+				"profileUrl": null
+			},
+			{
+				"id": 1393382,
+				"job": "Sound Effects Editor",
+				"name": "David Werntz",
+				"profileUrl": null
+			},
+			{
+				"id": 1393390,
+				"job": "Visual Effects Supervisor",
+				"name": "Ray McIntyre Jr.",
+				"profileUrl": null
+			},
+			{
+				"id": 1394130,
+				"job": "Sound Re-Recording Mixer",
+				"name": "Frank A. Montaño",
+				"profileUrl": null
+			},
+			{
+				"id": 1394739,
+				"job": "Art Department Coordinator",
+				"name": "Charlotte Raybourn",
+				"profileUrl": null
+			},
+			{
+				"id": 1394740,
+				"job": "Art Department Coordinator",
+				"name": "Hélène Lamarre",
+				"profileUrl": null
+			},
+			{
+				"id": 1394742,
+				"job": "Property Master",
+				"name": "Simon Chamberland",
+				"profileUrl": null
+			},
+			{
+				"id": 1394743,
+				"job": "Sculptor",
+				"name": "Hiroshi Yada",
+				"profileUrl": null
+			},
+			{
+				"id": 1394744,
+				"job": "Sculptor",
+				"name": "Keith Christensen",
+				"profileUrl": null
+			},
+			{
+				"id": 1394745,
+				"job": "Sculptor",
+				"name": "Marc Chow",
+				"profileUrl": null
+			},
+			{
+				"id": 1394746,
+				"job": "Greensman",
+				"name": "Martin Laneuville",
+				"profileUrl": null
+			},
+			{
+				"id": 1394747,
+				"job": "Dialogue Editor",
+				"name": "Miguel Rivera",
+				"profileUrl": null
+			},
+			{
+				"id": 1394748,
+				"job": "Special Effects Coordinator",
+				"name": "Stephen Gilbert",
+				"profileUrl": null
+			},
+			{
+				"id": 1394749,
+				"job": "Visual Effects Producer",
+				"name": "Andy Fowler",
+				"profileUrl": null
+			},
+			{
+				"id": 1394750,
+				"job": "Visual Effects Producer",
+				"name": "Thomas Nittmann",
+				"profileUrl": null
+			},
+			{
+				"id": 1394751,
+				"job": "Visual Effects Producer",
+				"name": "Persis Reynolds",
+				"profileUrl": null
+			},
+			{
+				"id": 1394752,
+				"job": "Visual Effects Producer",
+				"name": "Mandy Tankenson",
+				"profileUrl": null
+			},
+			{
+				"id": 1394753,
+				"job": "Visual Effects Editor",
+				"name": "George McCarthy",
+				"profileUrl": null
+			},
+			{
+				"id": 1394754,
+				"job": "Visual Effects Supervisor",
+				"name": "Kirsty Millar",
+				"profileUrl": null
+			},
+			{
+				"id": 1394755,
+				"job": "Visual Effects Supervisor",
+				"name": "Edson Williams",
+				"profileUrl": null
+			},
+			{
+				"id": 1394756,
+				"job": "Camera Operator",
+				"name": "Daniel Sauvé",
+				"profileUrl": null
+			},
+			{
+				"id": 1394756,
+				"job": "Steadicam Operator",
+				"name": "Daniel Sauvé",
+				"profileUrl": null
+			},
+			{
+				"id": 1394757,
+				"job": "Gaffer",
+				"name": "John Lewin",
+				"profileUrl": null
+			},
+			{
+				"id": 1394759,
+				"job": "Location Manager",
+				"name": "Pierre Blondin",
+				"profileUrl": null
+			},
+			{
+				"id": 1394760,
+				"job": "Script Supervisor",
+				"name": "Kimi Webber",
+				"profileUrl": null
+			},
+			{
+				"id": 1394761,
+				"job": "Choreographer",
+				"name": "Nadine Thouin",
+				"profileUrl": null
+			},
+			{
+				"id": 1394762,
+				"job": "Studio Teachers",
+				"name": "Jerie McBride",
+				"profileUrl": null
+			},
+			{
+				"id": 1400505,
+				"job": "Costume Assistant",
+				"name": "Jennifer Anderson",
+				"profileUrl": null
+			},
+			{
+				"id": 1401362,
+				"job": "Visual Effects Supervisor",
+				"name": "John 'D.J.' Des Jardin",
+				"profileUrl": null
+			},
+			{
+				"id": 1401720,
+				"job": "Compositing Supervisor",
+				"name": "Erik Liles",
+				"profileUrl": null
+			},
+			{
+				"id": 1402017,
+				"job": "Key Hair Stylist",
+				"name": "Réjean Forget",
+				"profileUrl": null
+			},
+			{
+				"id": 1404841,
+				"job": "ADR Supervisor",
+				"name": "Zack Davis",
+				"profileUrl": null
+			},
+			{
+				"id": 1405373,
+				"job": "Hair Department Head",
+				"name": "Audrey L. Anzures",
+				"profileUrl": null
+			},
+			{
+				"id": 1409714,
+				"job": "Rigging Gaffer",
+				"name": "Marco Venditto",
+				"profileUrl": null
+			},
+			{
+				"id": 1411540,
+				"job": "Digital Intermediate Producer",
+				"name": "Des Carey",
+				"profileUrl": null
+			},
+			{
+				"id": 1411541,
+				"job": "Digital Intermediate Producer",
+				"name": "Missy Papageorge",
+				"profileUrl": null
+			},
+			{
+				"id": 1415484,
+				"job": "Visual Effects Coordinator",
+				"name": "Ryan Zuttermeister",
+				"profileUrl": null
+			},
+			{
+				"id": 1418411,
+				"job": "First Assistant Editor",
+				"name": "Melissa Remenarich",
+				"profileUrl": null
+			},
+			{
+				"id": 1421269,
+				"job": "Compositing Supervisor",
+				"name": "Chris Holmes",
+				"profileUrl": null
+			},
+			{
+				"id": 1423861,
+				"job": "ADR Editor",
+				"name": "Jeff Rosen",
+				"profileUrl": null
+			},
+			{
+				"id": 1427715,
+				"job": "Stunts",
+				"name": "Jon Valera",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/kvcBOZCEMrHLwfsb7kUBDPl0AMk.jpg"
+			},
+			{
+				"id": 1433720,
+				"job": "Sound Effects Editor",
+				"name": "Jon Mete",
+				"profileUrl": null
+			},
+			{
+				"id": 1435190,
+				"job": "Foley Mixer",
+				"name": "Kyle Rochlin",
+				"profileUrl": null
+			},
+			{
+				"id": 1440299,
+				"job": "Sound Effects Editor",
+				"name": "Brad North",
+				"profileUrl": null
+			},
+			{
+				"id": 1441363,
+				"job": "Digital Effects Supervisor",
+				"name": "Cristin Pescosolido",
+				"profileUrl": null
+			},
+			{
+				"id": 1444295,
+				"job": "Digital Effects Supervisor",
+				"name": "Derek Wentworth",
+				"profileUrl": null
+			},
+			{
+				"id": 1447121,
+				"job": "Hairstylist",
+				"name": "Jean-Jacques Dion",
+				"profileUrl": null
+			},
+			{
+				"id": 1447122,
+				"job": "Key Makeup Artist",
+				"name": "Jocelyne Bellemare",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/9KZmZI9n1y5LeczwWnbk8kUj2be.jpg"
+			},
+			{
+				"id": 1447543,
+				"job": "Visual Effects",
+				"name": "Hugo Dominguez",
+				"profileUrl": null
+			},
+			{
+				"id": 1454514,
+				"job": "CG Supervisor",
+				"name": "Stephen Coren",
+				"profileUrl": null
+			},
+			{
+				"id": 1457325,
+				"job": "Lead Animator",
+				"name": "Michael Cozens",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/gv0NZ3pYtTjnLaZcia83VSgEJ7m.jpg"
+			},
+			{
+				"id": 1457896,
+				"job": "Post Production Supervisor",
+				"name": "Andrea Wertheim",
+				"profileUrl": null
+			},
+			{
+				"id": 1467332,
+				"job": "Digital Effects Supervisor",
+				"name": "Jake Morrison",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/7XDhwTphEl9YUhcLrQOhK0e6iX2.jpg"
+			},
+			{
+				"id": 1498167,
+				"job": "Second Unit Director",
+				"name": "Clay Staub",
+				"profileUrl": null
+			},
+			{
+				"id": 1515296,
+				"job": "CG Supervisor",
+				"name": "Chris Wells",
+				"profileUrl": null
+			},
+			{
+				"id": 15217,
+				"job": "Director",
+				"name": "Zack Snyder",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/iD0GDqkvJXDXiNEZej198hjt3Tt.jpg"
+			},
+			{
+				"id": 15217,
+				"job": "Screenplay",
+				"name": "Zack Snyder",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/iD0GDqkvJXDXiNEZej198hjt3Tt.jpg"
+			},
+			{
+				"id": 15221,
+				"job": "Original Music Composer",
+				"name": "Tyler Bates",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/vZiif8NFGpzCw5TWbagXIWygQM1.jpg"
+			},
+			{
+				"id": 15225,
+				"job": "Music Editor",
+				"name": "Darrell Hall",
+				"profileUrl": null
+			},
+			{
+				"id": 15226,
+				"job": "Supervising Sound Editor",
+				"name": "Scott Hecker",
+				"profileUrl": null
+			},
+			{
+				"id": 1525883,
+				"job": "Costume Assistant",
+				"name": "Martine Gagnon",
+				"profileUrl": null
+			},
+			{
+				"id": 1531246,
+				"job": "Armory Coordinator",
+				"name": "Serge Lavigueur",
+				"profileUrl": null
+			},
+			{
+				"id": 15357,
+				"job": "Visual Effects Producer",
+				"name": "Nina Fallon",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/ifgrJzYwA8Jpm0nMQtpRF3S6asc.jpg"
+			},
+			{
+				"id": 1550073,
+				"job": "Foley Supervisor",
+				"name": "Mark Pappas",
+				"profileUrl": null
+			},
+			{
+				"id": 1558715,
+				"job": "Visual Effects Coordinator",
+				"name": "Ryan Kuba",
+				"profileUrl": null
+			},
+			{
+				"id": 1569559,
+				"job": "Digital Effects Supervisor",
+				"name": "Tyler Foell",
+				"profileUrl": null
+			},
+			{
+				"id": 1574648,
+				"job": "Video Assist Operator",
+				"name": "Julie Garceau",
+				"profileUrl": null
+			},
+			{
+				"id": 1574668,
+				"job": "Modelling Supervisor",
+				"name": "Yoshiya Yamada",
+				"profileUrl": null
+			},
+			{
+				"id": 1587343,
+				"job": "Key Grip",
+				"name": "Robert B. Baylis",
+				"profileUrl": null
+			},
+			{
+				"id": 1610265,
+				"job": "Foley Editor",
+				"name": "Shawn Sykora",
+				"profileUrl": null
+			},
+			{
+				"id": 1611787,
+				"job": "Wardrobe Assistant",
+				"name": "Rosalie Clermont-Bilodeau",
+				"profileUrl": null
+			},
+			{
+				"id": 1620217,
+				"job": "Compositing Artist",
+				"name": "Martin Zwanzger",
+				"profileUrl": null
+			},
+			{
+				"id": 1631607,
+				"job": "Second Assistant \"B\" Camera",
+				"name": "Eric Aubin",
+				"profileUrl": null
+			},
+			{
+				"id": 1631613,
+				"job": "Grip",
+				"name": "Alain Bisson Doyal",
+				"profileUrl": null
+			},
+			{
+				"id": 16341,
+				"job": "Makeup Artist",
+				"name": "Christophe Giraud",
+				"profileUrl": null
+			},
+			{
+				"id": 1646489,
+				"job": "Concept Artist",
+				"name": "Meinert Hansen",
+				"profileUrl": null
+			},
+			{
+				"id": 1648160,
+				"job": "Stunts",
+				"name": "Dane Farwell",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/tw5vgvb46XdaZ3YVh49YObfsi9i.jpg"
+			},
+			{
+				"id": 1650750,
+				"job": "Extras Casting",
+				"name": "Julie Breton",
+				"profileUrl": null
+			},
+			{
+				"id": 1661417,
+				"job": "First Assistant Camera",
+				"name": "William R. Dalgleish",
+				"profileUrl": null
+			},
+			{
+				"id": 1662351,
+				"job": "Epk Camera Operator",
+				"name": "Noel Donnellon",
+				"profileUrl": null
+			},
+			{
+				"id": 1708271,
+				"job": "Lighting Technician",
+				"name": "Christian Chabot",
+				"profileUrl": null
+			},
+			{
+				"id": 1708278,
+				"job": "Set Designer",
+				"name": "Guy Pigeon",
+				"profileUrl": null
+			},
+			{
+				"id": 1710159,
+				"job": "Modeling",
+				"name": "Miguel Ortega",
+				"profileUrl": null
+			},
+			{
+				"id": 1725660,
+				"job": "First Assistant Camera",
+				"name": "Yves Drapeau",
+				"profileUrl": null
+			},
+			{
+				"id": 17284,
+				"job": "Director of Photography",
+				"name": "Larry Fong",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/4rS2YTxhtVBvc3pSCbxk6b6wGI6.jpg"
+			},
+			{
+				"id": 17285,
+				"job": "Screenplay",
+				"name": "Kurt Johnstad",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/tY7geoJ3T4kBnehGe4i26YQx4yL.jpg"
+			},
+			{
+				"id": 1733132,
+				"job": "Negative Cutter",
+				"name": "Mo Henry",
+				"profileUrl": null
+			},
+			{
+				"id": 1740487,
+				"job": "Title Designer",
+				"name": "Garson Yu",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/gYVX3VSuccLwX6DzzER68QkjzmM.jpg"
+			},
+			{
+				"id": 1753720,
+				"job": "Assistant Makeup Artist",
+				"name": "Catherine Lavoie",
+				"profileUrl": null
+			},
+			{
+				"id": 1759802,
+				"job": "CG Supervisor",
+				"name": "Yanick Wilisky",
+				"profileUrl": null
+			},
+			{
+				"id": 17610,
+				"job": "Casting",
+				"name": "Kristy Carlson",
+				"profileUrl": null
+			},
+			{
+				"id": 17611,
+				"job": "Casting",
+				"name": "Andrea Kenyon",
+				"profileUrl": null
+			},
+			{
+				"id": 17612,
+				"job": "Casting Associate",
+				"name": "Tamara-Lee Notcutt",
+				"profileUrl": null
+			},
+			{
+				"id": 17613,
+				"job": "Art Direction",
+				"name": "Nicolas Lepage",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/4cUFH9XnmNWjzqvAUUGlx2gknfn.jpg"
+			},
+			{
+				"id": 1762793,
+				"job": "Key Grip",
+				"name": "Alain Masse",
+				"profileUrl": null
+			},
+			{
+				"id": 1767007,
+				"job": "Dolly Grip",
+				"name": "Richard Boucher",
+				"profileUrl": null
+			},
+			{
+				"id": 1767009,
+				"job": "Chief Lighting Technician",
+				"name": "Jean Courteau",
+				"profileUrl": null
+			},
+			{
+				"id": 1790327,
+				"job": "Assistant Makeup Artist",
+				"name": "Gillian Chandler",
+				"profileUrl": null
+			},
+			{
+				"id": 1836437,
+				"job": "Casting Assistant",
+				"name": "Shawn Roberts",
+				"profileUrl": null
+			},
+			{
+				"id": 1856168,
+				"job": "Concept Artist",
+				"name": "Dan Milligan",
+				"profileUrl": null
+			},
+			{
+				"id": 1856795,
+				"job": "Visual Effects Coordinator",
+				"name": "Dean Gula",
+				"profileUrl": null
+			},
+			{
+				"id": 1861208,
+				"job": "Assistant Editor",
+				"name": "Nathan Gunn",
+				"profileUrl": null
+			},
+			{
+				"id": 1866579,
+				"job": "Stunt Coordinator",
+				"name": "Tad Griffith",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/izB74udztAJk6qbQSaks8co2Pv2.jpg"
+			},
+			{
+				"id": 1866579,
+				"job": "Stunts",
+				"name": "Tad Griffith",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/izB74udztAJk6qbQSaks8co2Pv2.jpg"
+			},
+			{
+				"id": 1866579,
+				"job": "Utility Stunts",
+				"name": "Tad Griffith",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/izB74udztAJk6qbQSaks8co2Pv2.jpg"
+			},
+			{
+				"id": 1869424,
+				"job": "Pre-Visualization Supervisor",
+				"name": "Chadi Abo",
+				"profileUrl": null
+			},
+			{
+				"id": 1890955,
+				"job": "Dolly Grip",
+				"name": "Patrice Lapointe",
+				"profileUrl": null
+			},
+			{
+				"id": 1906325,
+				"job": "Concept Artist",
+				"name": "Marco Nero",
+				"profileUrl": null
+			},
+			{
+				"id": 1929028,
+				"job": "Dresser",
+				"name": "Catherine Gélinas",
+				"profileUrl": null
+			},
+			{
+				"id": 1933025,
+				"job": "Second Assistant Camera",
+				"name": "Caroline Béliveau",
+				"profileUrl": null
+			},
+			{
+				"id": 1947504,
+				"job": "CG Supervisor",
+				"name": "Bret St. Clair",
+				"profileUrl": null
+			},
+			{
+				"id": 2004142,
+				"job": "Visual Effects Coordinator",
+				"name": "Jayne Herrmann",
+				"profileUrl": null
+			},
+			{
+				"id": 2005255,
+				"job": "Post Production Consulting",
+				"name": "Todd Baillere",
+				"profileUrl": null
+			},
+			{
+				"id": 2006448,
+				"job": "Set Dresser",
+				"name": "Louis Frederic Denomme",
+				"profileUrl": null
+			},
+			{
+				"id": 2028815,
+				"job": "Visual Effects Coordinator",
+				"name": "P. Whitney Gearin",
+				"profileUrl": null
+			},
+			{
+				"id": 2052768,
+				"job": "Visual Effects Coordinator",
+				"name": "Richard Cote",
+				"profileUrl": null
+			},
+			{
+				"id": 2054831,
+				"job": "Colorist",
+				"name": "Bill Holley",
+				"profileUrl": null
+			},
+			{
+				"id": 2057527,
+				"job": "Storyboard Artist",
+				"name": "Richard Bennett",
+				"profileUrl": null
+			},
+			{
+				"id": 20908,
+				"job": "Producer",
+				"name": "Jeffrey Silver",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/kVuCoDnUnTidGWS8sGEmkT4JDLB.jpg"
+			},
+			{
+				"id": 2092283,
+				"job": "Makeup Artist",
+				"name": "Larysa Chernienko",
+				"profileUrl": null
+			},
+			{
+				"id": 2122,
+				"job": "Editor",
+				"name": "William Hoy",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/v2CwZFJFSyH0qOLePJ7drfOEADi.jpg"
+			},
+			{
+				"id": 2130449,
+				"job": "3D Artist",
+				"name": "Nerys Lincoln",
+				"profileUrl": null
+			},
+			{
+				"id": 2134404,
+				"job": "Visual Effects Coordinator",
+				"name": "Danielle Rubin",
+				"profileUrl": null
+			},
+			{
+				"id": 2142803,
+				"job": "Compositing Artist",
+				"name": "Julia Reinhard",
+				"profileUrl": null
+			},
+			{
+				"id": 2145811,
+				"job": "Set Dresser",
+				"name": "Marco Lavallée",
+				"profileUrl": null
+			},
+			{
+				"id": 2151288,
+				"job": "Compositing Artist",
+				"name": "Sergio Ayrosa",
+				"profileUrl": null
+			},
+			{
+				"id": 2152210,
+				"job": "3D Modeller",
+				"name": "Andreas Nehls",
+				"profileUrl": null
+			},
+			{
+				"id": 2156277,
+				"job": "Online Editor",
+				"name": "Dylan Carter",
+				"profileUrl": null
+			},
+			{
+				"id": 2219999,
+				"job": "Grip",
+				"name": "Mathieu Price",
+				"profileUrl": null
+			},
+			{
+				"id": 2220009,
+				"job": "Second Assistant \"A\" Camera",
+				"name": "Sylvain Dupuis",
+				"profileUrl": null
+			},
+			{
+				"id": 2230126,
+				"job": "Generator Operator",
+				"name": "Stephane Boisvert",
+				"profileUrl": null
+			},
+			{
+				"id": 2236499,
+				"job": "Best Boy Grip",
+				"name": "David Dinel",
+				"profileUrl": null
+			},
+			{
+				"id": 2239596,
+				"job": "Dolly Grip",
+				"name": "Stephen Wells",
+				"profileUrl": null
+			},
+			{
+				"id": 2264569,
+				"job": "Best Boy Electrician",
+				"name": "Jeff Scott",
+				"profileUrl": null
+			},
+			{
+				"id": 2272172,
+				"job": "Animation Supervisor",
+				"name": "Joshua Cordes",
+				"profileUrl": null
+			},
+			{
+				"id": 2293,
+				"job": "Executive Producer",
+				"name": "Frank Miller",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/eFi56Bo2Hm0JR9MYTA1dJ4MKypu.jpg"
+			},
+			{
+				"id": 2293,
+				"job": "Novel",
+				"name": "Frank Miller",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/eFi56Bo2Hm0JR9MYTA1dJ4MKypu.jpg"
+			},
+			{
+				"id": 2302313,
+				"job": "Visual Effects Art Director",
+				"name": "Grant Freckelton",
+				"profileUrl": null
+			},
+			{
+				"id": 2333386,
+				"job": "Visual Effects Coordinator",
+				"name": "Karl Rogovin",
+				"profileUrl": null
+			},
+			{
+				"id": 2405273,
+				"job": "Lighting Technician",
+				"name": "Pierre Beaulieu",
+				"profileUrl": null
+			},
+			{
+				"id": 2426880,
+				"job": "Pyrotechnician",
+				"name": "Jacques Langlois",
+				"profileUrl": null
+			},
+			{
+				"id": 2504845,
+				"job": "Key Dresser",
+				"name": "Henri Aubertin",
+				"profileUrl": null
+			},
+			{
+				"id": 2545025,
+				"job": "VFX Artist",
+				"name": "Neal Sopata",
+				"profileUrl": null
+			},
+			{
+				"id": 2635883,
+				"job": "Assistant Makeup Artist",
+				"name": "Melina Di Cristo",
+				"profileUrl": null
+			},
+			{
+				"id": 2635884,
+				"job": "Assistant Makeup Artist",
+				"name": "Annick Legout",
+				"profileUrl": null
+			},
+			{
+				"id": 2635895,
+				"job": "Makeup Artist",
+				"name": "David Scott",
+				"profileUrl": null
+			},
+			{
+				"id": 2635899,
+				"job": "Tattooist",
+				"name": "Adam Forman",
+				"profileUrl": null
+			},
+			{
+				"id": 2635904,
+				"job": "Assistant Camera",
+				"name": "Christian Lemay",
+				"profileUrl": null
+			},
+			{
+				"id": 2635920,
+				"job": "Electrician",
+				"name": "Richard Alger",
+				"profileUrl": null
+			},
+			{
+				"id": 2635925,
+				"job": "Grip",
+				"name": "Robert Lapierre Jr.",
+				"profileUrl": null
+			},
+			{
+				"id": 2635926,
+				"job": "Grip",
+				"name": "Martine Vincent",
+				"profileUrl": null
+			},
+			{
+				"id": 2635927,
+				"job": "Rigging Grip",
+				"name": "Sandrin Olivier",
+				"profileUrl": null
+			},
+			{
+				"id": 2635939,
+				"job": "Dresser",
+				"name": "Tereska Gesing",
+				"profileUrl": null
+			},
+			{
+				"id": 2635941,
+				"job": "Key Dresser",
+				"name": "Pascal Gauthier",
+				"profileUrl": null
+			},
+			{
+				"id": 2635944,
+				"job": "Title Designer",
+				"name": "Yolanda Santosa",
+				"profileUrl": null
+			},
+			{
+				"id": 2637014,
+				"job": "Art Department Production Assistant",
+				"name": "Caroline Lachance",
+				"profileUrl": null
+			},
+			{
+				"id": 2637034,
+				"job": "Storyboard Artist",
+				"name": "Mark Alan Yates",
+				"profileUrl": null
+			},
+			{
+				"id": 2638489,
+				"job": "Compositing Artist",
+				"name": "Stephan Schweizer",
+				"profileUrl": null
+			},
+			{
+				"id": 2638498,
+				"job": "Modelling Supervisor",
+				"name": "Cesar Dacol Jr.",
+				"profileUrl": null
+			},
+			{
+				"id": 2638507,
+				"job": "Visual Effects Coordinator",
+				"name": "Chris Capell",
+				"profileUrl": null
+			},
+			{
+				"id": 2638509,
+				"job": "Visual Effects Coordinator",
+				"name": "Marie-Claude Aubry",
+				"profileUrl": null
+			},
+			{
+				"id": 2638511,
+				"job": "Visual Effects Coordinator",
+				"name": "Marie-Chantale Savard-Côté",
+				"profileUrl": null
+			},
+			{
+				"id": 2638513,
+				"job": "Visual Effects Coordinator",
+				"name": "Ana Marie Cruz",
+				"profileUrl": null
+			},
+			{
+				"id": 2638521,
+				"job": "Assistant Editor",
+				"name": "Elizabeth Ross",
+				"profileUrl": null
+			},
+			{
+				"id": 2638523,
+				"job": "Colorist",
+				"name": "Éric Gaudry",
+				"profileUrl": null
+			},
+			{
+				"id": 2757468,
+				"job": "Research Assistant",
+				"name": "Larissa Lowthorp",
+				"profileUrl": null
+			},
+			{
+				"id": 30034,
+				"job": "Rigging Gaffer",
+				"name": "Gilles Fortier",
+				"profileUrl": null
+			},
+			{
+				"id": 3241398,
+				"job": "VFX Artist",
+				"name": "Arild Anfinnsen",
+				"profileUrl": null
+			},
+			{
+				"id": 3369518,
+				"job": "Costumer",
+				"name": "Marie-Maude Grenier",
+				"profileUrl": null
+			},
+			{
+				"id": 3618256,
+				"job": "Visual Effects Coordinator",
+				"name": "Lisa Marra",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/vxMw691NJz8hxzoUUIhEr3qoTBe.jpg"
+			},
+			{
+				"id": 37685,
+				"job": "Visual Effects Producer",
+				"name": "Ismat Zaidi",
+				"profileUrl": null
+			},
+			{
+				"id": 40644,
+				"job": "Stunt Coordinator",
+				"name": "Chad Stahelski",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/eRCryGwKDH4XqUlrdkERmeBWPo8.jpg"
+			},
+			{
+				"id": 40684,
+				"job": "Stunts",
+				"name": "David Leitch",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/qykhwWkXTAteD9yvsmItXh9LxCq.jpg"
+			},
+			{
+				"id": 5392,
+				"job": "Costume Design",
+				"name": "Michael Wilkinson",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/tD8iThER9b45YaDqgOqtAFFmEHd.jpg"
+			},
+			{
+				"id": 54211,
+				"job": "Executive Producer",
+				"name": "Thomas Tull",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/gRvTHmNKEqzyt2sGvpjrAvmloy0.jpg"
+			},
+			{
+				"id": 54212,
+				"job": "Executive Producer",
+				"name": "William Fay",
+				"profileUrl": null
+			},
+			{
+				"id": 55081,
+				"job": "Stunts",
+				"name": "Jonathan Eusebio",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/wYpBkb8CkkxqF3wA1hQd55Bg8R8.jpg"
+			},
+			{
+				"id": 59055,
+				"job": "ADR Voice Casting",
+				"name": "Caitlin McKenna",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/cPfk4htR9X7gUnr1jYsKs0Y5qBq.jpg"
+			},
+			{
+				"id": 59932,
+				"job": "Additional Casting",
+				"name": "Lindsey Hayes Kroeger",
+				"profileUrl": null
+			},
+			{
+				"id": 60245,
+				"job": "Executive Producer",
+				"name": "Scott Mednick",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/bSAAg6Kkh47pg9gAr3Wo2DbEMtH.jpg"
+			},
+			{
+				"id": 6037,
+				"job": "Visual Effects Supervisor",
+				"name": "Colin Strause",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/l2kKglzUn9j2Hgio3lBzOXErHfc.jpg"
+			},
+			{
+				"id": 6038,
+				"job": "Visual Effects Supervisor",
+				"name": "Greg Strause",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/uYLWnaZ0yTR24ykfgkROElCwiP6.jpg"
+			},
+			{
+				"id": 6053,
+				"job": "Set Decoration",
+				"name": "Paul Hotte",
+				"profileUrl": null
+			},
+			{
+				"id": 6232,
+				"job": "Casting",
+				"name": "Carrie Hilton",
+				"profileUrl": null
+			},
+			{
+				"id": 62723,
+				"job": "Colorist",
+				"name": "Stefan Sonnenfeld",
+				"profileUrl": null
+			},
+			{
+				"id": 65377,
+				"job": "Producer",
+				"name": "Bernie Goldmann",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/d2MBN9LkiQ9zyFy4fDei2om9Lqz.jpg"
+			},
+			{
+				"id": 6874,
+				"job": "Executive Producer",
+				"name": "Ben Waisbren",
+				"profileUrl": null
+			},
+			{
+				"id": 79242,
+				"job": "Associate Producer",
+				"name": "Wesley Coller",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/aFzXWzhy8NcvsbiNMuSEwLRjQrB.jpg"
+			},
+			{
+				"id": 79243,
+				"job": "Executive Producer",
+				"name": "Deborah Snyder",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/iu3gfcEqJY47Ab111XSoX1U18EW.jpg"
+			},
+			{
+				"id": 84338,
+				"job": "Stunts",
+				"name": "Clint Carleton",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/qUcF9fBQNxcCyiZAjcwlrOAkLj2.jpg"
+			},
+			{
+				"id": 8704,
+				"job": "Supervising Art Director",
+				"name": "Isabelle Guay",
+				"profileUrl": null
+			},
+			{
+				"id": 90690,
+				"job": "Second Unit Director of Photography",
+				"name": "Mirosław Baszak",
+				"profileUrl": null
+			},
+			{
+				"id": 92234,
+				"job": "Stunts",
+				"name": "Jean Frenette",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/Ao5PfsZNMyF8FgcxFCl27vSy8NR.jpg"
+			},
+			{
+				"id": 92235,
+				"job": "Stunt Coordinator",
+				"name": "Stéphane Lefebvre",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/v8EUN9jpDt7BzaOMEC2nJbazfdC.jpg"
+			},
+			{
+				"id": 92237,
+				"job": "Camera Operator",
+				"name": "François Daignault",
+				"profileUrl": null
+			},
+			{
+				"id": 95835,
+				"job": "Supervising Sound Effects Editor",
+				"name": "Eric A. Norris",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/mksvxvfNqhFM8lsKSckosiOWYpq.jpg"
+			},
+			{
+				"id": 977988,
+				"job": "First Assistant Director",
+				"name": "Martin Walters",
+				"profileUrl": null
+			},
+			{
+				"id": 9967,
+				"job": "Production Design",
+				"name": "James D. Bissell",
+				"profileUrl": "https://image.tmdb.org/t/p/w500/1rKagQ6kZnEWaa8CJaoWTLQUkBh.jpg"
+			}
+		],
+		"genres": ["Action", "Adventure", "War"],
+		"homepage": "http://300themovie.warnerbros.com",
+		"id": "be3ff291-459a-4ebe-a217-5f5235fc56ff",
+		"imdbId": "tt0416449",
+		"lastRefreshedAt": "2026-02-27T18:20:21.024Z",
+		"originalLanguage": "en",
+		"originalTitle": "300",
+		"overview": "Based on Frank Miller's graphic novel, \"300\" is very loosely based the 480 B.C. Battle of Thermopylae, where the King of Sparta led his army against the advancing Persians; the battle is said to have inspired all of Greece to band together against the Persians, and helped usher in the world's first democracy.",
+		"popularity": 10,
+		"posterPath": null,
+		"posterUrl": "https://image.tmdb.org/t/p/w500/h7Lcio0c9ohxPhSZg42eTlKIVVY.jpg",
+		"backdropUrl": "https://media.themoviedb.org/t/p/w1920_and_h800_multi_faces/lgBZlJ1LHQel5nneNQMoesmvc7l.jpg",
+		"productionCompanies": [
+			{
+				"logoUrl": "https://image.tmdb.org/t/p/w500/5UQsZrfbfG2dYJbx8DxfoTr2Bvu.png",
+				"name": "Legendary Pictures",
+				"originCountry": "US"
+			},
+			{
+				"logoUrl": "https://image.tmdb.org/t/p/w500/drzD5Yq9aQuDEbNxlTAhmlL2izx.png",
+				"name": "Atmosphere Entertainment MM",
+				"originCountry": "US"
+			},
+			{
+				"logoUrl": "https://image.tmdb.org/t/p/w500/fV3x8bowlRCXKtkWDovLYco7cOK.png",
+				"name": "Virtual Studios",
+				"originCountry": "US"
+			},
+			{
+				"logoUrl": "https://image.tmdb.org/t/p/w500/jg4nWIIjQ49APUHqTWZ09gArhF8.png",
+				"name": "Hollywood Gang Productions",
+				"originCountry": "US"
+			},
+			{
+				"logoUrl": "https://image.tmdb.org/t/p/w500/mAIGhOYhN4N2N0F7p4dbKhgXf3l.png",
+				"name": "Cruel & Unusual Films",
+				"originCountry": "US"
+			},
+			{
+				"logoUrl": "https://image.tmdb.org/t/p/w500/zhD3hhtKB5qyv7ZeL4uLpNxgMVU.png",
+				"name": "Warner Bros. Pictures",
+				"originCountry": "US"
+			}
+		],
+		"productionCountries": ["United States of America"],
+		"releaseDate": "2007-03-07T00:00:00.000Z",
+		"revenue": 456082343,
+		"runtime": 116,
+		"spokenLanguages": [
+			{
+				"englishName": "English",
+				"iso639_1": "en",
+				"name": "English"
+			}
+		],
+		"status": "Released",
+		"title": "300",
+		"tmdbId": 1271,
+		"updatedAt": "2026-02-27T18:20:21.024Z",
+		"videos": []
+	}
+]

--- a/src/routes/movie/index.tsx
+++ b/src/routes/movie/index.tsx
@@ -1,0 +1,154 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { CardItem } from "@/components/cards/card.tsx";
+import { Grid } from "@/components/layouts/grid.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import {
+	Carousel,
+	CarouselContent,
+	CarouselItem,
+	CarouselNext,
+	CarouselPrevious,
+} from "@/components/ui/carousel.tsx";
+import movies from "@/lib/mockups/movies.json";
+
+export const Route = createFileRoute("/movie/")({
+	component: MovieRoute,
+});
+
+function MovieRoute() {
+	const { t } = useTranslation();
+
+	return (
+		<div className="mx-auto w-full">
+			<Carousel
+				className="w-full"
+				opts={{
+					loop: true,
+					align: "center",
+				}}
+			>
+				<CarouselContent>
+					{movies.map((movie) => {
+						return (
+							<CarouselItem key={movie.id}>
+								<div className="relative w-full overflow-hidden rounded-xl border border-border">
+									<img
+										src={movie.backdropUrl}
+										className="w-full h-60 md:h-120 object-cover"
+										alt={movie.title}
+									/>
+
+									<div className="absolute inset-0 bg-linear-to-t from-malachite-500/80 via-malachite-500/30 to-transparent" />
+
+									<div className="absolute inset-0 p-8 flex flex-col justify-end gap-4">
+										<h2 className="text-4xl font-bold drop-shadow-lg">
+											{movie.title}
+										</h2>
+
+										<div className="max-w-2xl hidden md:block">
+											<p className="text-lg line-clamp-2 text-white/90 drop-shadow-md">
+												{movie.overview}
+											</p>
+										</div>
+
+										<Link
+											to={`/movie/${movie.id}`}
+											className="bg-primary text-primary-foreground w-fit px-6 py-2 rounded-full font-semibold hover:brightness-110 transition-all shadow-lg"
+										>
+											{t("common:viewDetails")}
+										</Link>
+									</div>
+								</div>
+							</CarouselItem>
+						);
+					})}
+				</CarouselContent>
+				<CarouselPrevious
+					variant="default"
+					className="left-4 bg-white border-none hover:bg-white/80 z-10"
+				/>
+				<CarouselNext
+					variant="default"
+					className="right-4 bg-white border-none hover:bg-white/80 z-10"
+				/>
+			</Carousel>
+			<div className="py-6 space-y-4">
+				<div className="flex items-center justify-between mb-4">
+					<p className="text-2xl font-bold">{t("feed:trending")}</p>
+					<Button>{t("pages:donate.viewAll")}</Button>
+				</div>
+				<Grid minColSize={"120px"} className={"grid-cols-5"}>
+					{movies.map((movie) => (
+						<CardItem
+							title={movie.title}
+							url={`/movie/${movie.id}`}
+							imageURL={movie.posterUrl}
+							rating={movie.rating || 0}
+							year={new Date(movie.releaseDate).getFullYear()}
+							synopsis={movie.overview}
+							mediaType={"movie"}
+							key={movie.id}
+						/>
+					))}
+				</Grid>
+				<div className="flex items-center justify-between mb-4">
+					<p className="text-2xl font-bold">{t("common:mostPopular")}</p>
+					<Button>{t("pages:donate.viewAll")}</Button>
+				</div>
+				<Grid minColSize={"120px"} className={"grid-cols-5"}>
+					{movies.map((movie) => (
+						<CardItem
+							title={movie.title}
+							url={`/movie/${movie.id}`}
+							imageURL={movie.posterUrl}
+							rating={movie.rating || 0}
+							year={new Date(movie.releaseDate).getFullYear()}
+							synopsis={movie.overview}
+							mediaType={"movie"}
+							key={movie.id}
+						/>
+					))}
+				</Grid>
+				<div className="flex items-center justify-between mb-4">
+					<p className="text-2xl font-bold">
+						{t("library:statusAir.currentlyAiring")}
+					</p>
+					<Button>{t("pages:donate.viewAll")}</Button>
+				</div>
+				<Grid minColSize={"120px"} className={"grid-cols-5"}>
+					{movies.map((movie) => (
+						<CardItem
+							title={movie.title}
+							url={`/movie/${movie.id}`}
+							imageURL={movie.posterUrl}
+							rating={movie.rating || 0}
+							year={new Date(movie.releaseDate).getFullYear()}
+							synopsis={movie.overview}
+							mediaType={"movie"}
+							key={movie.id}
+						/>
+					))}
+				</Grid>
+				<div className="flex items-center justify-between mb-4">
+					<p className="text-2xl font-bold">{t("common:comingSoon")}</p>
+					<Button>{t("pages:donate.viewAll")}</Button>
+				</div>
+				<Grid minColSize={"120px"} className={"grid-cols-5"}>
+					{movies.map((movie) => (
+						<CardItem
+							title={movie.title}
+							url={`/movie/${movie.id}`}
+							imageURL={movie.posterUrl}
+							rating={movie.rating || 0}
+							year={new Date(movie.releaseDate).getFullYear()}
+							synopsis={movie.overview}
+							mediaType={"movie"}
+							key={movie.id}
+						/>
+					))}
+				</Grid>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Introduced the `/movie` route showcasing mock data for movies, including cast, crew, budget, collections, and metadata. Updated the header link to reflect the new route for improved navigation consistency. Closes #74 

## Acknowledgements
- [x] I read the [PR Guidelines](https://github.com/TrackGeek/web/blob/main/.github/CONTRIBUTING.md)
- [x] I linted and formatted the code by running `npm run check`
- [x] The PR title follows the repo's [commit conventions](https://github.com/TrackGeek/web/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    At least TWO screenshots of the feature
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated movie showcase page with an interactive carousel featuring highlighted films
  * Added grid sections displaying trending, popular, and upcoming movies with ratings and synopses
  * Integrated direct navigation links to individual movie detail pages

* **Navigation**
  * Updated header menu navigation to link to the new movie section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->