### PR TITLE
feat: add review modal with status-based triggers and enhance modals …

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**/*", "!**/node_modules/**", "!**/dist/**", "!**/.tanstack/**"]
+    "includes": ["**/*", "!**/node_modules", "!**/dist", "!**/.tanstack"]
   },
   "formatter": {
     "enabled": true,
@@ -21,6 +21,9 @@
       "recommended": true,
       "style": {
         "useImportType": "off"
+      },
+      "suspicious": {
+        "noArrayIndexKey": "off"
       }
     }
   },

--- a/src/components/kibo-ui/editor/index.tsx
+++ b/src/components/kibo-ui/editor/index.tsx
@@ -117,15 +117,6 @@ export const defaultSlashSuggestions: SuggestionOptions<SuggestionItem>["items"]
     },
   },
   {
-    title: "To-do List",
-    description: "Track tasks with a to-do list.",
-    searchTerms: ["todo", "task", "list", "check", "checkbox"],
-    icon: CheckSquareIcon,
-    command: ({ editor, range }) => {
-      editor.chain().focus().deleteRange(range).toggleList("taskList", "taskItem").run();
-    },
-  },
-  {
     title: "Heading 1",
     description: "Big section heading.",
     searchTerms: ["title", "big", "large"],

--- a/src/components/rating-group-advanced.tsx
+++ b/src/components/rating-group-advanced.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { HeartIcon, StarIcon } from "lucide-react";
+import * as React from "react";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+
+interface RatingGroupAdvancedProps {
+  value?: string;
+  onValueChange?: (value: string) => void;
+  max?: number;
+  className?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  size?: "sm" | "default" | "lg";
+  variant?: "star" | "heart";
+  allowHalf?: boolean;
+  emptyIcon?: React.ComponentType<{ className?: string }>;
+  filledIcon?: React.ComponentType<{ className?: string }>;
+  colors?: {
+    filled?: string;
+    empty?: string;
+    hover?: string;
+  };
+  allowClear?: boolean;
+}
+
+const defaultColors = {
+  filled: "fill-yellow-400 text-yellow-400",
+  empty: "text-muted-foreground/50",
+  hover: "text-yellow-300",
+};
+
+const iconVariants = {
+  star: StarIcon,
+  heart: HeartIcon,
+};
+
+function RatingGroupAdvanced({
+  value = "0",
+  onValueChange,
+  max = 5,
+  className,
+  disabled = false,
+  readOnly = false,
+  size = "default",
+  variant = "star",
+  allowHalf = false,
+  emptyIcon,
+  filledIcon,
+  colors = defaultColors,
+  allowClear = false,
+  ...props
+}: RatingGroupAdvancedProps) {
+  const [hoveredValue, setHoveredValue] = React.useState<number | null>(null);
+
+  const currentValue = React.useMemo(() => parseFloat(value || "0"), [value]);
+  const displayValue = hoveredValue ?? currentValue;
+
+  const EmptyIcon = emptyIcon || iconVariants[variant];
+  const FilledIcon = filledIcon || iconVariants[variant];
+
+  const indices = React.useMemo(() => Array.from({ length: max }, (_, i) => i + 1), [max]);
+
+  const handleMouseEnter = React.useCallback(
+    (starValue: number, isHalf?: boolean) => {
+      if (!disabled && !readOnly) {
+        const finalValue = allowHalf && isHalf ? starValue - 0.5 : starValue;
+        setHoveredValue(finalValue);
+      }
+    },
+    [disabled, readOnly, allowHalf],
+  );
+
+  const handleMouseLeave = React.useCallback(() => {
+    setHoveredValue(null);
+  }, []);
+
+  const handleClick = React.useCallback(
+    (starValue: number, isHalf?: boolean) => {
+      if (!disabled && !readOnly && onValueChange) {
+        const finalValue = allowHalf && isHalf ? starValue - 0.5 : starValue;
+        const newValue = allowClear && currentValue === finalValue ? "0" : finalValue.toString();
+        onValueChange(newValue);
+      }
+    },
+    [disabled, readOnly, onValueChange, allowHalf, allowClear, currentValue],
+  );
+
+  const getIconState = (index: number) => {
+    const value = displayValue;
+    if (value >= index) return "filled";
+    if (allowHalf && value >= index - 0.5) return "half";
+    return "empty";
+  };
+
+  const sizeClasses = {
+    sm: "size-4",
+    default: "size-5",
+    lg: "size-6",
+  };
+
+  return (
+    <div className="relative">
+      <ToggleGroup
+        type={allowHalf ? "multiple" : "single"}
+        value={[value]}
+        onValueChange={(groupValue) => onValueChange?.(groupValue[groupValue.length - 1] || "0")}
+        size={size}
+        className={cn("gap-0", className)}
+        disabled={disabled}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        {indices.map((index) => {
+          const starValue = index.toString();
+          const iconState = getIconState(index);
+
+          return (
+            <div key={starValue} className="relative">
+              <ToggleGroupItem
+                value={starValue}
+                aria-label={`${index} rating`}
+                className={cn(
+                  "relative border-0 bg-transparent p-0 hover:bg-transparent data-[state=on]:bg-transparent focus-visible:ring-0",
+                  "hover:scale-110 focus-visible:scale-110 transition-transform ease-out",
+                  (disabled || readOnly) && "pointer-events-none opacity-50",
+                )}
+                disabled={disabled || readOnly}
+              >
+                {allowHalf ? (
+                  <div className="relative">
+                    <div
+                      className="absolute inset-0 w-1/2 z-10 cursor-pointer"
+                      onMouseEnter={() => handleMouseEnter(index, true)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleClick(index, true);
+                      }}
+                    />
+                    <div
+                      className="absolute inset-0 left-1/2 w-1/2 z-10 cursor-pointer"
+                      onMouseEnter={() => handleMouseEnter(index, false)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleClick(index, false);
+                      }}
+                    />
+                    <div className="relative">
+                      {iconState === "half" ? (
+                        <div className="relative">
+                          <EmptyIcon className={cn("transition-colors ease-out", sizeClasses[size], colors.empty)} />
+                          <div className="absolute inset-0 overflow-hidden w-1/2">
+                            <FilledIcon
+                              className={cn("transition-colors ease-out", sizeClasses[size], colors.filled)}
+                            />
+                          </div>
+                        </div>
+                      ) : (
+                        <FilledIcon
+                          className={cn(
+                            "transition-colors ease-out",
+                            sizeClasses[size],
+                            iconState === "filled" ? colors.filled : colors.empty,
+                          )}
+                        />
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <div onMouseEnter={() => handleMouseEnter(index)}>
+                    <FilledIcon
+                      className={cn(
+                        "transition-colors ease-out",
+                        sizeClasses[size],
+                        iconState === "filled" ? colors.filled : colors.empty,
+                      )}
+                    />
+                  </div>
+                )}
+              </ToggleGroupItem>
+            </div>
+          );
+        })}
+      </ToggleGroup>
+    </div>
+  );
+}
+
+export { RatingGroupAdvanced };

--- a/src/components/shared/cards/card.tsx
+++ b/src/components/shared/cards/card.tsx
@@ -1,12 +1,14 @@
 import { Link } from "@tanstack/react-router";
 import { ChevronDown, Heart, Star } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../../ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "../../ui/dialog";
 import { BookModal } from "../modals/book";
 import { EpisodicContentModal } from "../modals/episodic-content";
 import { GameModal } from "../modals/game";
 import { MangaModal } from "../modals/manga";
 import { MovieModal } from "../modals/movie";
-import { Button } from "../../ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "../../ui/dialog";
+import { ReviewModal } from "../modals/review";
 
 type MediaType = "anime" | "movie" | "tv-show" | "game" | "book" | "manga";
 
@@ -21,7 +23,22 @@ interface CardProps {
   mediaData?: any;
 }
 
-export function CardItem({ title, url, rating, year, imageURL, mediaType, synopsis }: CardProps) {
+export function CardItem({ title, url, rating, year, imageURL, mediaType, synopsis, mediaData }: CardProps) {
+  const [mainDialogOpen, setMainDialogOpen] = useState(false);
+  const [reviewDialogOpen, setReviewDialogOpen] = useState(false);
+  const [mediaStatus, setMediaStatus] = useState<string | null>(null);
+
+  const handleStatusChange = (status: string) => {
+    setMediaStatus(status);
+  };
+
+  const handleSaveSuccess = (status: string) => {
+    if (status === "completed" || status === "finished" || status === "played") {
+      setMainDialogOpen(false);
+      setReviewDialogOpen(true);
+    }
+  };
+
   return (
     <div>
       <div className="relative rounded-xl border border-border overflow-hidden aspect-3/4 group">
@@ -34,7 +51,7 @@ export function CardItem({ title, url, rating, year, imageURL, mediaType, synops
           />
         </Link>
 
-        <Dialog>
+        <Dialog open={mainDialogOpen} onOpenChange={setMainDialogOpen}>
           <DialogTrigger asChild>
             <Button
               variant="secondary"
@@ -80,15 +97,25 @@ export function CardItem({ title, url, rating, year, imageURL, mediaType, synops
             </DialogHeader>
 
             <div className="overflow-y-auto max-h-[calc(90vh-12rem)]">
-              {(mediaType === "anime" || mediaType === "tv-show") && <EpisodicContentModal />}
-              {mediaType === "movie" && <MovieModal />}
-              {mediaType === "book" && <BookModal />}
-              {mediaType === "game" && <GameModal />}
-              {mediaType === "manga" && <MangaModal />}
+              {(mediaType === "anime" || mediaType === "tv-show") && (
+                <EpisodicContentModal onStatusChange={handleStatusChange} onSaveSuccess={handleSaveSuccess} />
+              )}
+              {mediaType === "movie" && <MovieModal onStatusChange={handleStatusChange} onSaveSuccess={handleSaveSuccess} />}
+              {mediaType === "book" && <BookModal onStatusChange={handleStatusChange} onSaveSuccess={handleSaveSuccess} />}
+              {mediaType === "game" && <GameModal onStatusChange={handleStatusChange} onSaveSuccess={handleSaveSuccess} />}
+              {mediaType === "manga" && <MangaModal onStatusChange={handleStatusChange} onSaveSuccess={handleSaveSuccess} />}
             </div>
           </DialogContent>
         </Dialog>
       </div>
+
+      <ReviewModal
+        open={reviewDialogOpen}
+        onOpenChange={setReviewDialogOpen}
+        mediaTitle={title}
+        mediaImage={imageURL}
+      />
+
       <Link to={url}>
         <p className="font-bold text-card-foreground mt-2 hover:text-primary transition-colors line-clamp-2">{title}</p>
       </Link>

--- a/src/components/shared/modals/book.tsx
+++ b/src/components/shared/modals/book.tsx
@@ -14,16 +14,25 @@ import { Textarea } from "../../ui/textarea";
 
 interface BookModalProps {
   mediaData?: any;
+  onStatusChange?: (status: string) => void;
+  onSaveSuccess?: (status: string) => void;
 }
 
-export function BookModal({ mediaData: _ }: BookModalProps) {
+export function BookModal({ mediaData: _, onStatusChange, onSaveSuccess }: BookModalProps) {
   const [startDate, setStartDate] = useState<Date>();
   const [finishDate, setFinishDate] = useState<Date>();
   const [customLists, setCustomLists] = useState<string[]>(["2026", "Favorites", "Read Later"]);
+  const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
   const { t } = useTranslation();
 
   const toggleCustomList = (list: string) => {
     setCustomLists((prev) => (prev.includes(list) ? prev.filter((l) => l !== list) : [...prev, list]));
+  };
+
+  const handleSave = async () => {
+    if (selectedStatus) {
+      onSaveSuccess?.(selectedStatus);
+    }
   };
 
   return (
@@ -40,7 +49,10 @@ export function BookModal({ mediaData: _ }: BookModalProps) {
                 <FieldLabel htmlFor="status" className="text-sm font-medium">
                   {t("library:status")}
                 </FieldLabel>
-                <Select>
+                <Select onValueChange={(value) => {
+                  setSelectedStatus(value);
+                  onStatusChange?.(value);
+                }}>
                   <SelectTrigger className="w-full bg-background">
                     <SelectValue placeholder={t("feed:selectStatus")} />
                   </SelectTrigger>
@@ -179,7 +191,7 @@ export function BookModal({ mediaData: _ }: BookModalProps) {
           <Button variant="outline" size="sm">
             {t("feed:cancel")}
           </Button>
-          <Button size="sm" className="gap-2">
+          <Button size="sm" className="gap-2" onClick={handleSave}>
             <Save className="size-4" />
             {t("feed:save")}
           </Button>

--- a/src/components/shared/modals/episodic-content.tsx
+++ b/src/components/shared/modals/episodic-content.tsx
@@ -14,9 +14,10 @@ import { Textarea } from "../../ui/textarea";
 
 interface EpisodicContentModalProps {
   mediaData?: any;
+  onStatusChange?: (status: string) => void;
 }
 
-export function EpisodicContentModal({ mediaData: _ }: EpisodicContentModalProps) {
+export function EpisodicContentModal({ mediaData: _, onStatusChange }: EpisodicContentModalProps) {
   const [startDate, setStartDate] = useState<Date>();
   const [finishDate, setFinishDate] = useState<Date>();
   const [customLists, setCustomLists] = useState<string[]>(["2026", "Favorites", "Watch Later"]);
@@ -40,7 +41,7 @@ export function EpisodicContentModal({ mediaData: _ }: EpisodicContentModalProps
                 <FieldLabel htmlFor="status" className="text-sm font-medium">
                   {t("library:status")}
                 </FieldLabel>
-                <Select>
+                <Select onValueChange={(value) => onStatusChange?.(value)}>
                   <SelectTrigger className="w-full bg-background">
                     <SelectValue placeholder={t("feed:selectStatus")} />
                   </SelectTrigger>

--- a/src/components/shared/modals/game.tsx
+++ b/src/components/shared/modals/game.tsx
@@ -14,12 +14,15 @@ import { Textarea } from "../../ui/textarea";
 
 interface GameModalProps {
   mediaData?: any;
+  onStatusChange?: (status: string) => void;
+  onSaveSuccess?: (status: string) => void;
 }
 
-export function GameModal({ mediaData: _ }: GameModalProps) {
+export function GameModal({ mediaData: _, onStatusChange, onSaveSuccess }: GameModalProps) {
   const [startDate, setStartDate] = useState<Date>();
   const [finishDate, setFinishDate] = useState<Date>();
   const [customLists, setCustomLists] = useState<string[]>(["2026", "Favorites", "Play Later"]);
+  const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
   const { t } = useTranslation();
 
   const toggleCustomList = (list: string) => {
@@ -28,6 +31,12 @@ export function GameModal({ mediaData: _ }: GameModalProps) {
 
   const handleDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
+  };
+
+  const handleSave = async () => {
+    if (selectedStatus) {
+      onSaveSuccess?.(selectedStatus);
+    }
   };
 
   return (
@@ -44,7 +53,12 @@ export function GameModal({ mediaData: _ }: GameModalProps) {
                 <FieldLabel htmlFor="status" className="text-sm font-medium">
                   {t("library:status")}
                 </FieldLabel>
-                <Select>
+                <Select
+                  onValueChange={(value) => {
+                    setSelectedStatus(value);
+                    onStatusChange?.(value);
+                  }}
+                >
                   <SelectTrigger className="w-full bg-background">
                     <SelectValue placeholder={t("feed:selectStatus")} />
                   </SelectTrigger>
@@ -230,7 +244,7 @@ export function GameModal({ mediaData: _ }: GameModalProps) {
           <Button variant="outline" size="sm">
             {t("feed:cancel")}
           </Button>
-          <Button size="sm" className="gap-2">
+          <Button size="sm" className="gap-2" onClick={handleSave}>
             <Save className="size-4" />
             {t("feed:save")}
           </Button>

--- a/src/components/shared/modals/manga.tsx
+++ b/src/components/shared/modals/manga.tsx
@@ -18,14 +18,21 @@ interface MangaModalProps {
   onSaveSuccess?: (status: string) => void;
 }
 
-export function MangaModal({ mediaData: _, onStatusChange }: MangaModalProps) {
+export function MangaModal({ mediaData: _, onStatusChange, onSaveSuccess }: MangaModalProps) {
   const [startDate, setStartDate] = useState<Date>();
   const [finishDate, setFinishDate] = useState<Date>();
   const [customLists, setCustomLists] = useState<string[]>(["2026", "Favorites", "Read Later"]);
+  const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
   const { t } = useTranslation();
 
   const toggleCustomList = (list: string) => {
     setCustomLists((prev) => (prev.includes(list) ? prev.filter((l) => l !== list) : [...prev, list]));
+  };
+
+  const handleSave = async () => {
+    if (selectedStatus) {
+      onSaveSuccess?.(selectedStatus);
+    }
   };
 
   return (
@@ -42,7 +49,12 @@ export function MangaModal({ mediaData: _, onStatusChange }: MangaModalProps) {
                 <FieldLabel htmlFor="status" className="text-sm font-medium">
                   {t("library:status")}
                 </FieldLabel>
-                <Select onValueChange={(value) => onStatusChange?.(value)}>
+                <Select
+                  onValueChange={(value) => {
+                    setSelectedStatus(value);
+                    onStatusChange?.(value);
+                  }}
+                >
                   <SelectTrigger className="w-full bg-background">
                     <SelectValue placeholder={t("feed:selectStatus")} />
                   </SelectTrigger>
@@ -193,7 +205,7 @@ export function MangaModal({ mediaData: _, onStatusChange }: MangaModalProps) {
           <Button variant="outline" size="sm">
             {t("feed:cancel")}
           </Button>
-          <Button size="sm" className="gap-2">
+          <Button size="sm" className="gap-2" onClick={handleSave}>
             <Save className="size-4" />
             {t("feed:save")}
           </Button>

--- a/src/components/shared/modals/manga.tsx
+++ b/src/components/shared/modals/manga.tsx
@@ -14,9 +14,11 @@ import { Textarea } from "../../ui/textarea";
 
 interface MangaModalProps {
   mediaData?: any;
+  onStatusChange?: (status: string) => void;
+  onSaveSuccess?: (status: string) => void;
 }
 
-export function MangaModal({ mediaData: _ }: MangaModalProps) {
+export function MangaModal({ mediaData: _, onStatusChange }: MangaModalProps) {
   const [startDate, setStartDate] = useState<Date>();
   const [finishDate, setFinishDate] = useState<Date>();
   const [customLists, setCustomLists] = useState<string[]>(["2026", "Favorites", "Read Later"]);
@@ -40,7 +42,7 @@ export function MangaModal({ mediaData: _ }: MangaModalProps) {
                 <FieldLabel htmlFor="status" className="text-sm font-medium">
                   {t("library:status")}
                 </FieldLabel>
-                <Select>
+                <Select onValueChange={(value) => onStatusChange?.(value)}>
                   <SelectTrigger className="w-full bg-background">
                     <SelectValue placeholder={t("feed:selectStatus")} />
                   </SelectTrigger>

--- a/src/components/shared/modals/movie.tsx
+++ b/src/components/shared/modals/movie.tsx
@@ -13,16 +13,25 @@ import { Textarea } from "../../ui/textarea";
 
 interface MovieModalProps {
   mediaData?: any;
+  onStatusChange?: (status: string) => void;
+  onSaveSuccess?: (status: string) => void;
 }
 
-export function MovieModal({ mediaData: _ }: MovieModalProps) {
+export function MovieModal({ mediaData: _, onStatusChange, onSaveSuccess }: MovieModalProps) {
   const [startDate, setStartDate] = useState<Date>();
   const [finishDate, setFinishDate] = useState<Date>();
   const [customLists, setCustomLists] = useState<string[]>(["2026", "Favorites", "Watch Later"]);
+  const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
   const { t } = useTranslation();
 
   const toggleCustomList = (list: string) => {
     setCustomLists((prev) => (prev.includes(list) ? prev.filter((l) => l !== list) : [...prev, list]));
+  };
+
+  const handleSave = async () => {
+    if (selectedStatus) {
+      onSaveSuccess?.(selectedStatus);
+    }
   };
 
   return (
@@ -39,7 +48,12 @@ export function MovieModal({ mediaData: _ }: MovieModalProps) {
                 <FieldLabel htmlFor="status" className="text-sm font-medium">
                   {t("library:status")}
                 </FieldLabel>
-                <Select>
+                <Select
+                  onValueChange={(value) => {
+                    setSelectedStatus(value);
+                    onStatusChange?.(value);
+                  }}
+                >
                   <SelectTrigger className="w-full bg-background">
                     <SelectValue placeholder={t("feed:selectStatus")} />
                   </SelectTrigger>
@@ -184,7 +198,7 @@ export function MovieModal({ mediaData: _ }: MovieModalProps) {
           <Button variant="outline" size="sm">
             {t("feed:cancel")}
           </Button>
-          <Button size="sm" className="gap-2">
+          <Button size="sm" className="gap-2" onClick={handleSave}>
             <Save className="size-4" />
             {t("feed:save")}
           </Button>

--- a/src/components/shared/modals/review.tsx
+++ b/src/components/shared/modals/review.tsx
@@ -10,8 +10,8 @@ import { Input } from "@/components/ui/input.tsx";
 interface ReviewModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mediaTitle?: string;
-  mediaImage?: string;
+  mediaTitle: string;
+  mediaImage: string;
   ratingCriteria?: Array<{ id: string; label: string }>;
 }
 
@@ -23,7 +23,7 @@ export function ReviewModal({
   ratingCriteria = [
     { id: "gameplay", label: "Gameplay" },
     { id: "graphics", label: "Graphics" },
-    { id: "sound", label: "Áudio" },
+    { id: "sound", label: "Audio" },
     { id: "story", label: "Story" },
   ],
 }: ReviewModalProps) {
@@ -133,7 +133,7 @@ export function ReviewModal({
               <div className="space-y-2 mb-4">
                 {pros.map((pro, index) => (
                   <div
-                    key={pro}
+                    key={`pro-${index}`}
                     className="flex items-center justify-between gap-2 bg-background rounded-md px-3 py-2 border border-border/50"
                   >
                     <span className="text-sm flex-1">{pro}</span>
@@ -169,7 +169,7 @@ export function ReviewModal({
               <div className="space-y-2 mb-4">
                 {cons.map((con, index) => (
                   <div
-                    key={con}
+                    key={`con-${index}`}
                     className="flex items-center justify-between gap-2 bg-background rounded-md px-3 py-2 border border-border/50"
                   >
                     <span className="text-sm flex-1">{con}</span>

--- a/src/components/shared/modals/review.tsx
+++ b/src/components/shared/modals/review.tsx
@@ -1,0 +1,216 @@
+import { Check, Plus, Trash2, XIcon } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { FeedComposer } from "@/components/pages/feed/composer.tsx";
+import { RatingGroupAdvanced } from "@/components/rating-group-advanced.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog.tsx";
+import { Input } from "@/components/ui/input.tsx";
+
+interface ReviewModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mediaTitle?: string;
+  mediaImage?: string;
+  ratingCriteria?: Array<{ id: string; label: string }>;
+}
+
+export function ReviewModal({
+  open,
+  onOpenChange,
+  mediaTitle = "Media Title",
+  mediaImage,
+  ratingCriteria = [
+    { id: "gameplay", label: "Gameplay" },
+    { id: "graphics", label: "Graphics" },
+    { id: "sound", label: "Áudio" },
+    { id: "story", label: "Story" },
+  ],
+}: ReviewModalProps) {
+  const { t } = useTranslation();
+  const [overallRating, setOverallRating] = useState("0");
+  const [criteriaRatings, setCriteriaRatings] = useState<Record<string, string>>(
+    Object.fromEntries(ratingCriteria.map((c) => [c.id, "0"])),
+  );
+  const [pros, setPros] = useState<string[]>([]);
+  const [cons, setCons] = useState<string[]>([]);
+  const [newPro, setNewPro] = useState("");
+  const [newCon, setNewCon] = useState("");
+
+  const handleAddPro = () => {
+    if (newPro.trim()) {
+      setPros([...pros, newPro.trim()]);
+      setNewPro("");
+    }
+  };
+
+  const handleRemovePro = (index: number) => {
+    setPros(pros.filter((_, i) => i !== index));
+  };
+
+  const handleAddCon = () => {
+    if (newCon.trim()) {
+      setCons([...cons, newCon.trim()]);
+      setNewCon("");
+    }
+  };
+
+  const handleRemoveCon = (index: number) => {
+    setCons(cons.filter((_, i) => i !== index));
+  };
+
+  const handleCriteriaChange = (criteriaId: string, value: string) => {
+    setCriteriaRatings((prev) => ({ ...prev, [criteriaId]: value }));
+  };
+
+  const handleSubmit = () => {
+    console.log({
+      overallRating,
+      criteriaRatings,
+      pros,
+      cons,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-hidden p-0 flex flex-col">
+        <DialogHeader className="h-48 p-4 flex flex-row items-center bg-cover bg-center px-6 relative rounded-t-lg">
+          {mediaImage && (
+            <>
+              <div
+                className="absolute inset-0 bg-cover bg-center rounded-t-lg"
+                style={{
+                  backgroundImage: `linear-gradient(to right, rgba(0,0,0,0.8), rgba(0,0,0,0.4)), url("${mediaImage}")`,
+                }}
+              />
+              <div className="absolute inset-0 backdrop-blur-sm bg-black/20 rounded-t-lg" />
+            </>
+          )}
+
+          <img
+            src={mediaImage}
+            alt="Cover"
+            className="w-24 h-32 object-cover rounded-lg shadow-2xl relative z-10 border-2 border-white/30"
+          />
+          <div className="flex-1 px-6 relative z-10">
+            <DialogTitle className="text-white font-bold text-2xl drop-shadow-lg">{mediaTitle}</DialogTitle>
+          </div>
+        </DialogHeader>
+
+        <div className="overflow-y-auto flex-1 px-6 space-y-6">
+          <div className="bg-card rounded-lg p-4 border border-border/50">
+            <div className="flex items-center justify-between gap-4">
+              <h3 className="font-semibold text-foreground">{t("feed:overall")}</h3>
+              <RatingGroupAdvanced max={5} allowHalf={true} value={overallRating} onValueChange={setOverallRating} />
+            </div>
+            <hr className="my-4" />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {ratingCriteria.map((criteria) => (
+                <div key={criteria.id} className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    {/** biome-ignore lint/a11y/noLabelWithoutControl: no form */}
+                    <label className="text-sm font-medium">{criteria.label}</label>
+                    <RatingGroupAdvanced
+                      max={5}
+                      allowHalf={true}
+                      value={criteriaRatings[criteria.id]}
+                      onValueChange={(value) => handleCriteriaChange(criteria.id, value)}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="bg-green-500/5 rounded-lg p-4 border border-green-500/20">
+              <h3 className="font-semibold text-foreground mb-3 flex items-center gap-2">
+                <Check className="text-green-600" />
+                {t("feed:pros")}
+              </h3>
+              <div className="space-y-2 mb-4">
+                {pros.map((pro, index) => (
+                  <div
+                    key={pro}
+                    className="flex items-center justify-between gap-2 bg-background rounded-md px-3 py-2 border border-border/50"
+                  >
+                    <span className="text-sm flex-1">{pro}</span>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => handleRemovePro(index)}
+                      className="h-6 w-6 p-0"
+                    >
+                      <Trash2 className="size-3" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+              <div className="flex gap-2 w-full items-center">
+                <Input
+                  placeholder={t("feed:addPositive")}
+                  value={newPro}
+                  onChange={(e) => setNewPro(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleAddPro()}
+                  className="text-sm w-full"
+                />
+                <Button onClick={handleAddPro} size="sm" variant="outline" className="px-3 h-9">
+                  <Plus className="size-4 grow" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="bg-red-500/5 rounded-lg p-4 border border-red-500/20">
+              <h3 className="font-semibold text-foreground mb-3 flex items-center gap-2">
+                <XIcon className="text-red-600" /> {t("feed:cons")}
+              </h3>
+              <div className="space-y-2 mb-4">
+                {cons.map((con, index) => (
+                  <div
+                    key={con}
+                    className="flex items-center justify-between gap-2 bg-background rounded-md px-3 py-2 border border-border/50"
+                  >
+                    <span className="text-sm flex-1">{con}</span>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => handleRemoveCon(index)}
+                      className="h-6 w-6 p-0"
+                    >
+                      <Trash2 className="size-3" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+              <div className="flex gap-2 items-center w-full">
+                <Input
+                  placeholder={t("feed:addNegative")}
+                  value={newCon}
+                  onChange={(e) => setNewCon(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleAddCon()}
+                  className="text-sm w-full"
+                />
+                <Button onClick={handleAddCon} size="sm" variant="outline" className="px-3 h-9">
+                  <Plus className="size-4" />
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <FeedComposer />
+        </div>
+
+        <div className="border-t border-border px-6 py-4 flex justify-between gap-3 bg-background rounded-b-lg">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("feed:cancel")}
+          </Button>
+          <Button onClick={handleSubmit} className="gap-2">
+            {t("feed:save")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,13 +1,12 @@
-import * as React from "react";
-
-import { cn } from "@/lib/utils";
 import { Eye, EyeOff } from "lucide-react";
+import * as React from "react";
+import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   const [shownPassword, setShownPassword] = React.useState(false);
 
   return (
-    <div className="relative">
+    <div className="w-full">
       <input
         type={shownPassword ? "text" : type}
         data-slot="input"

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -6,7 +6,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   const [shownPassword, setShownPassword] = React.useState(false);
 
   return (
-    <div className="w-full">
+    <div className="relative w-full">
       <input
         type={shownPassword ? "text" : type}
         data-slot="input"

--- a/src/lib/i18n/locales/en-US/feed.json
+++ b/src/lib/i18n/locales/en-US/feed.json
@@ -73,5 +73,10 @@
     "mainStoryPlusExtras": "Main Story + Extras",
     "endless": "Endless"
   },
-  "uploadScreenshot": "Drag and drop or <span>choose screenshots</span> to upload"
+  "uploadScreenshot": "Drag and drop or <span>choose screenshots</span> to upload",
+  "addNegative": "Add a Negative Point",
+  "addPositive": "Add a Positive Point",
+  "pros": "Pros",
+  "cons": "Cons",
+  "overall": "Overall"
 }


### PR DESCRIPTION
## Description
- Introduced a `ReviewModal` for capturing user reviews with ratings, pros/cons, and overall impressions.
- Enhanced status change handling across modals (e.g., Book, Movie, Game) with callbacks for `onStatusChange` and `onSaveSuccess`.
- Updated `CardItem` to conditionally open `ReviewModal` based on media completion status.
- Expanded localization keys for pros/cons and review-specific terms in `feed.json`.
- Removed unused "To-do List" configuration from the editor for cleanup.

## Acknowledgements
- [x] I read the [PR Guidelines](https://github.com/TrackGeek/web/blob/main/.github/CONTRIBUTING.md)
- [x] I linted and formatted the code by running `npm run check`
- [x] The PR title follows the repo's [commit conventions](https://github.com/TrackGeek/web/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    At least TWO screenshots of the feature
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive rating control supporting stars/hearts, half-values, clearing, and customizable styling.
  * Comprehensive review modal for submitting overall and criteria-based ratings plus pros/cons.
  * Card details now support a status/save flow that can open the review modal after completion.

* **Bug Fixes / Refactor**
  * Removed the "To‑do List" slash command from the editor.

* **Chores**
  * Added translation strings for the review interface (pros/cons/overall/add buttons).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->