### PR TITLE
feat(franchises): add routes

### DIFF
--- a/src/components/pages/feed/composer.tsx
+++ b/src/components/pages/feed/composer.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { Editor, JSONContent } from "@/components/kibo-ui/editor";
+import type { Editor, JSONContent } from "@/components/ui/editor.tsx";
 import {
   EditorBubbleMenu,
   EditorClearFormatting,
@@ -37,7 +37,7 @@ import {
   EditorTableRowDelete,
   EditorTableRowMenu,
   EditorTableSplitCell,
-} from "@/components/kibo-ui/editor";
+} from "@/components/ui/editor.tsx";
 
 export function FeedComposer() {
   const { t } = useTranslation();

--- a/src/components/shared/header/index.tsx
+++ b/src/components/shared/header/index.tsx
@@ -70,7 +70,8 @@ export function Header() {
         </DropdownMenu>
 
         <Link to={session.data?.user ? "/feed" : "/"}>
-          <img src="/logo.svg" alt="Logo" className="h-10" />
+          <img src="/logo.svg" alt="Logo" className="h-10 max-sm:hidden" />
+          <img src="/favicon.svg" alt="Logo" className="h-10 sm:hidden" />
         </Link>
       </div>
 

--- a/src/components/shared/modals/review.tsx
+++ b/src/components/shared/modals/review.tsx
@@ -2,10 +2,10 @@ import { Check, Plus, Trash2, XIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FeedComposer } from "@/components/pages/feed/composer.tsx";
-import { RatingGroupAdvanced } from "@/components/rating-group-advanced.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog.tsx";
 import { Input } from "@/components/ui/input.tsx";
+import { RatingGroupAdvanced } from "@/components/ui/rating-group-advanced.tsx";
 
 interface ReviewModalProps {
   open: boolean;

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,12 +1,9 @@
-"use client";
-
-import * as React from "react";
 import { Combobox as ComboboxPrimitive } from "@base-ui/react";
 import { CheckIcon, ChevronDownIcon, XIcon } from "lucide-react";
-
-import { cn } from "@/lib/utils";
+import * as React from "react";
 import { Button } from "@/components/ui/button";
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group";
+import { cn } from "@/lib/utils";
 
 const Combobox = ComboboxPrimitive.Root;
 

--- a/src/components/ui/editor.tsx
+++ b/src/components/ui/editor.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Editor, Range } from "@tiptap/core";
 import { mergeAttributes, Node } from "@tiptap/core";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
@@ -19,18 +17,18 @@ import {
   useCurrentEditor,
 } from "@tiptap/react";
 import { BubbleMenu, type BubbleMenuProps, type FloatingMenuProps } from "@tiptap/react/menus";
-import { Button } from "@/components/ui/button";
-import { Command, CommandEmpty, CommandItem, CommandList } from "@/components/ui/command";
+import { Button } from "@/components/ui/button.tsx";
+import { Command, CommandEmpty, CommandItem, CommandList } from "@/components/ui/command.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Separator } from "@/components/ui/separator";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
+} from "@/components/ui/dropdown-menu.tsx";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover.tsx";
+import { Separator } from "@/components/ui/separator.tsx";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip.tsx";
+import { cn } from "@/lib/utils.ts";
 
 export type { Editor, JSONContent } from "@tiptap/react";
 

--- a/src/components/ui/rating-group-advanced.tsx
+++ b/src/components/ui/rating-group-advanced.tsx
@@ -1,9 +1,7 @@
-"use client";
-
 import { HeartIcon, StarIcon } from "lucide-react";
 import * as React from "react";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { cn } from "@/lib/utils";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.tsx";
+import { cn } from "@/lib/utils.ts";
 
 interface RatingGroupAdvancedProps {
   value?: string;

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,11 +1,8 @@
-"use client";
-
-import * as React from "react";
 import { type VariantProps } from "class-variance-authority";
 import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
-
-import { cn } from "@/lib/utils";
+import * as React from "react";
 import { toggleVariants } from "@/components/ui/toggle";
+import { cn } from "@/lib/utils";
 
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants> & {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -33,6 +33,9 @@ import { Route as BookSlugRouteImport } from './routes/book/$slug'
 import { Route as AnimeSlugRouteImport } from './routes/anime/$slug'
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
 import { Route as UserUsernameIndexRouteImport } from './routes/user/$username/index'
+import { Route as MovieFranchisesSlugRouteImport } from './routes/movie/franchises/$slug'
+import { Route as GameFranchisesSlugRouteImport } from './routes/game/franchises/$slug'
+import { Route as BookFranchisesSlugRouteImport } from './routes/book/franchises/$slug'
 import { Route as UserUsernameSerieIndexRouteImport } from './routes/user/$username/serie/index'
 import { Route as UserUsernameScreenshotsIndexRouteImport } from './routes/user/$username/screenshots/index'
 import { Route as UserUsernameReviewsIndexRouteImport } from './routes/user/$username/reviews/index'
@@ -161,6 +164,21 @@ const UserUsernameIndexRoute = UserUsernameIndexRouteImport.update({
   path: '/user/$username/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const MovieFranchisesSlugRoute = MovieFranchisesSlugRouteImport.update({
+  id: '/movie/franchises/$slug',
+  path: '/movie/franchises/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GameFranchisesSlugRoute = GameFranchisesSlugRouteImport.update({
+  id: '/game/franchises/$slug',
+  path: '/game/franchises/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BookFranchisesSlugRoute = BookFranchisesSlugRouteImport.update({
+  id: '/book/franchises/$slug',
+  path: '/book/franchises/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UserUsernameSerieIndexRoute = UserUsernameSerieIndexRouteImport.update({
   id: '/user/$username/serie/',
   path: '/user/$username/serie/',
@@ -227,6 +245,9 @@ export interface FileRoutesByFullPath {
   '/manga/': typeof MangaIndexRoute
   '/movie/': typeof MovieIndexRoute
   '/tv/': typeof TvIndexRoute
+  '/book/franchises/$slug': typeof BookFranchisesSlugRoute
+  '/game/franchises/$slug': typeof GameFranchisesSlugRoute
+  '/movie/franchises/$slug': typeof MovieFranchisesSlugRoute
   '/user/$username/': typeof UserUsernameIndexRoute
   '/user/$username/anime/': typeof UserUsernameAnimeIndexRoute
   '/user/$username/book/': typeof UserUsernameBookIndexRoute
@@ -260,6 +281,9 @@ export interface FileRoutesByTo {
   '/manga': typeof MangaIndexRoute
   '/movie': typeof MovieIndexRoute
   '/tv': typeof TvIndexRoute
+  '/book/franchises/$slug': typeof BookFranchisesSlugRoute
+  '/game/franchises/$slug': typeof GameFranchisesSlugRoute
+  '/movie/franchises/$slug': typeof MovieFranchisesSlugRoute
   '/user/$username': typeof UserUsernameIndexRoute
   '/user/$username/anime': typeof UserUsernameAnimeIndexRoute
   '/user/$username/book': typeof UserUsernameBookIndexRoute
@@ -295,6 +319,9 @@ export interface FileRoutesById {
   '/manga/': typeof MangaIndexRoute
   '/movie/': typeof MovieIndexRoute
   '/tv/': typeof TvIndexRoute
+  '/book/franchises/$slug': typeof BookFranchisesSlugRoute
+  '/game/franchises/$slug': typeof GameFranchisesSlugRoute
+  '/movie/franchises/$slug': typeof MovieFranchisesSlugRoute
   '/user/$username/': typeof UserUsernameIndexRoute
   '/user/$username/anime/': typeof UserUsernameAnimeIndexRoute
   '/user/$username/book/': typeof UserUsernameBookIndexRoute
@@ -330,6 +357,9 @@ export interface FileRouteTypes {
     | '/manga/'
     | '/movie/'
     | '/tv/'
+    | '/book/franchises/$slug'
+    | '/game/franchises/$slug'
+    | '/movie/franchises/$slug'
     | '/user/$username/'
     | '/user/$username/anime/'
     | '/user/$username/book/'
@@ -363,6 +393,9 @@ export interface FileRouteTypes {
     | '/manga'
     | '/movie'
     | '/tv'
+    | '/book/franchises/$slug'
+    | '/game/franchises/$slug'
+    | '/movie/franchises/$slug'
     | '/user/$username'
     | '/user/$username/anime'
     | '/user/$username/book'
@@ -397,6 +430,9 @@ export interface FileRouteTypes {
     | '/manga/'
     | '/movie/'
     | '/tv/'
+    | '/book/franchises/$slug'
+    | '/game/franchises/$slug'
+    | '/movie/franchises/$slug'
     | '/user/$username/'
     | '/user/$username/anime/'
     | '/user/$username/book/'
@@ -431,6 +467,9 @@ export interface RootRouteChildren {
   MangaIndexRoute: typeof MangaIndexRoute
   MovieIndexRoute: typeof MovieIndexRoute
   TvIndexRoute: typeof TvIndexRoute
+  BookFranchisesSlugRoute: typeof BookFranchisesSlugRoute
+  GameFranchisesSlugRoute: typeof GameFranchisesSlugRoute
+  MovieFranchisesSlugRoute: typeof MovieFranchisesSlugRoute
   UserUsernameIndexRoute: typeof UserUsernameIndexRoute
   UserUsernameAnimeIndexRoute: typeof UserUsernameAnimeIndexRoute
   UserUsernameBookIndexRoute: typeof UserUsernameBookIndexRoute
@@ -612,6 +651,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserUsernameIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/movie/franchises/$slug': {
+      id: '/movie/franchises/$slug'
+      path: '/movie/franchises/$slug'
+      fullPath: '/movie/franchises/$slug'
+      preLoaderRoute: typeof MovieFranchisesSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/game/franchises/$slug': {
+      id: '/game/franchises/$slug'
+      path: '/game/franchises/$slug'
+      fullPath: '/game/franchises/$slug'
+      preLoaderRoute: typeof GameFranchisesSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/book/franchises/$slug': {
+      id: '/book/franchises/$slug'
+      path: '/book/franchises/$slug'
+      fullPath: '/book/franchises/$slug'
+      preLoaderRoute: typeof BookFranchisesSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/user/$username/serie/': {
       id: '/user/$username/serie/'
       path: '/user/$username/serie'
@@ -706,6 +766,9 @@ const rootRouteChildren: RootRouteChildren = {
   MangaIndexRoute: MangaIndexRoute,
   MovieIndexRoute: MovieIndexRoute,
   TvIndexRoute: TvIndexRoute,
+  BookFranchisesSlugRoute: BookFranchisesSlugRoute,
+  GameFranchisesSlugRoute: GameFranchisesSlugRoute,
+  MovieFranchisesSlugRoute: MovieFranchisesSlugRoute,
   UserUsernameIndexRoute: UserUsernameIndexRoute,
   UserUsernameAnimeIndexRoute: UserUsernameAnimeIndexRoute,
   UserUsernameBookIndexRoute: UserUsernameBookIndexRoute,

--- a/src/routes/book/franchises/$slug.tsx
+++ b/src/routes/book/franchises/$slug.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Grid } from "@/components/layouts/grid.tsx";
+import { CardItem } from "@/components/shared/cards/card.tsx";
+import booksData from "@/lib/mockups/books.json";
+
+export const Route = createFileRoute("/book/franchises/$slug")({
+  component: BookFranchisesRoute,
+});
+
+function BookFranchisesRoute() {
+  const { slug: _ } = Route.useParams();
+  const books = booksData;
+
+  return (
+    <div className="mx-auto w-full space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Heartstopper</h1>
+      <Grid minColSize={"120px"} className={"grid-cols-5"}>
+        {books.map((book) => (
+          <CardItem
+            title={book.title}
+            url={`/book/${book.id}`}
+            imageURL={book.imageUrl}
+            rating={0}
+            year={book.releaseYear}
+            synopsis={book.description}
+            mediaType={"book"}
+            key={book.id}
+          />
+        ))}
+      </Grid>
+    </div>
+  );
+}

--- a/src/routes/game/franchises/$slug.tsx
+++ b/src/routes/game/franchises/$slug.tsx
@@ -1,0 +1,52 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Grid } from "@/components/layouts/grid.tsx";
+import { CardItem } from "@/components/shared/cards/card.tsx";
+import gamesData from "@/lib/mockups/games.json";
+
+export const Route = createFileRoute("/game/franchises/$slug")({
+  component: GameFranchiseRoute,
+});
+
+function GameFranchiseRoute() {
+  const { slug: _ } = Route.useParams();
+  const games = Array.isArray(gamesData) ? gamesData : [gamesData.game];
+
+  return (
+    <div className="mx-auto w-full">
+      {games.map((game) => {
+        const artworks = Array.isArray(game.artworks) ? game.artworks : [];
+        const keyArt = artworks.find((a: any) => a.type === "Key art without logo")?.url;
+
+        return (
+          <div className="relative w-full overflow-hidden rounded-xl border border-border" key={game.id}>
+            <img
+              src={keyArt || game.coverUrl}
+              className="w-full h-60 md:h-100 object-cover object-top"
+              alt={game.name}
+            />
+
+            <div className="absolute inset-0 bg-linear-to-t from-malachite-500/80 via-malachite-500/30 to-transparent" />
+
+            <div className="absolute inset-0 p-8 flex flex-col justify-end gap-4">
+              <h2 className="text-4xl font-bold drop-shadow-lg">{game.name}</h2>
+            </div>
+          </div>
+        );
+      })}
+      <Grid minColSize={"120px"} className={"grid-cols-5 py-6"}>
+        {games.map((game) => (
+          <CardItem
+            title={game.name}
+            url={`/game/${game.id}`}
+            imageURL={game.coverUrl}
+            rating={game.rating}
+            year={new Date(game.releaseDates[0].date).getFullYear()}
+            synopsis={game.summary}
+            mediaType={"game"}
+            key={game.id}
+          />
+        ))}
+      </Grid>
+    </div>
+  );
+}

--- a/src/routes/movie/franchises/$slug.tsx
+++ b/src/routes/movie/franchises/$slug.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Grid } from "@/components/layouts/grid.tsx";
+import { CardItem } from "@/components/shared/cards/card.tsx";
+import movies from "@/lib/mockups/movies.json";
+
+export const Route = createFileRoute("/movie/franchises/$slug")({
+  component: MovieFranchiseRoute,
+});
+
+function MovieFranchiseRoute() {
+  const { slug: _ } = Route.useParams();
+
+  return (
+    <div className="mx-auto w-full">
+      {movies.slice(0, 1).map((movie) => {
+        return (
+          <div className="relative w-full overflow-hidden rounded-xl border border-border" key={movie.id}>
+            <img src={movie.backdropUrl} className="w-full h-60 md:h-100 object-cover" alt={movie.title} />
+
+            <div className="absolute inset-0 bg-linear-to-t from-malachite-500/80 via-malachite-500/30 to-transparent" />
+
+            <div className="absolute inset-0 p-8 flex flex-col justify-end gap-4">
+              <h2 className="text-4xl font-bold drop-shadow-lg">{movie.title}</h2>
+
+              <div className="max-w-2xl hidden md:block">
+                <p className="text-lg line-clamp-2 text-white/90 drop-shadow-md">{movie.overview}</p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      <Grid minColSize={"120px"} className={"grid-cols-5 py-6"}>
+        {movies.map((movie) => (
+          <CardItem
+            title={movie.title}
+            url={`/movie/${movie.id}`}
+            imageURL={movie.posterUrl}
+            rating={0}
+            year={new Date(movie.releaseDate).getFullYear()}
+            synopsis={movie.overview}
+            mediaType={"movie"}
+            key={movie.id}
+          />
+        ))}
+      </Grid>
+    </div>
+  );
+}

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { createFileRoute } from "@tanstack/react-router";
 import { Clipboard } from "lucide-react";
 import { useState } from "react";


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [PR Guidelines](https://github.com/TrackGeek/web/blob/main/.github/CONTRIBUTING.md)
- [x] I linted and formatted the code by running `npm run check`
- [x] The PR title follows the repo's [commit conventions](https://github.com/TrackGeek/web/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    At least TWO screenshots of the feature
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added franchise detail pages for books, games, and movies with dynamic slug-based routing, displaying content in responsive grid layouts
  * Header logo is now responsive—full logo on larger screens, favicon on mobile devices

* **Refactor**
  * Consolidated internal import paths for UI components across the codebase
  * Removed unnecessary directives from several components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->